### PR TITLE
Add unit tests for match package

### DIFF
--- a/backend/src/test/java/com/pawconnect/backend/match/controller/MatchControllerTest.java
+++ b/backend/src/test/java/com/pawconnect/backend/match/controller/MatchControllerTest.java
@@ -1,0 +1,71 @@
+package com.pawconnect.backend.match.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawconnect.backend.common.enums.SwipeDecision;
+import com.pawconnect.backend.match.dto.CandidateUserResponse;
+import com.pawconnect.backend.match.dto.SwipeCreateRequest;
+import com.pawconnect.backend.match.service.MatchService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+class MatchControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private MatchService matchService; // injected mock
+
+    private CandidateUserResponse candidate;
+    private SwipeCreateRequest swipeRequest;
+
+    @BeforeEach
+    void setUp() {
+        candidate = CandidateUserResponse.builder().id(5L).username("u").build();
+        swipeRequest = new SwipeCreateRequest(2L, SwipeDecision.LIKE);
+    }
+
+    @Test
+    void candidates_returnsList() throws Exception {
+        when(matchService.getCandidates(20,25)).thenReturn(List.of(candidate));
+
+        mockMvc.perform(get("/api/matches/candidates"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(5));
+    }
+
+    @Test
+    void swipe_returnsCreated() throws Exception {
+        mockMvc.perform(post("/api/matches/swipes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(swipeRequest)))
+                .andExpect(status().isCreated());
+
+        verify(matchService).swipe(any(SwipeCreateRequest.class));
+    }
+
+    @Configuration
+    @Import(MatchController.class)
+    static class TestConfig {
+        @Bean
+        MatchService matchService() {
+            return Mockito.mock(MatchService.class);
+        }
+    }
+}

--- a/backend/src/test/java/com/pawconnect/backend/match/service/MatchServiceTest.java
+++ b/backend/src/test/java/com/pawconnect/backend/match/service/MatchServiceTest.java
@@ -1,0 +1,137 @@
+package com.pawconnect.backend.match.service;
+
+import com.pawconnect.backend.common.enums.SwipeDecision;
+import com.pawconnect.backend.match.dto.CandidateUserResponse;
+import com.pawconnect.backend.match.dto.SwipeCreateRequest;
+import com.pawconnect.backend.match.dto.RankedCandidateRow;
+import com.pawconnect.backend.match.model.Match;
+import com.pawconnect.backend.match.model.Swipe;
+import com.pawconnect.backend.match.repository.MatchRepository;
+import com.pawconnect.backend.match.repository.SwipeRepository;
+import com.pawconnect.backend.user.dto.PublicUserResponse;
+import com.pawconnect.backend.user.dto.UserMapper;
+import com.pawconnect.backend.user.model.User;
+import com.pawconnect.backend.user.model.UserGender;
+import com.pawconnect.backend.user.repository.UserRepository;
+import com.pawconnect.backend.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MatchServiceTest {
+
+    @Mock
+    private MatchRepository matchRepository;
+    @Mock
+    private SwipeRepository swipeRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private UserService userService;
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private MatchService matchService;
+
+    private User currentUser;
+    private User targetUser;
+    private Point point;
+
+    @BeforeEach
+    void setUp() {
+        point = new GeometryFactory().createPoint(new Coordinate(1.0,2.0));
+        currentUser = User.builder().id(1L).location(point).build();
+        targetUser = User.builder().id(2L).build();
+    }
+
+    @Test
+    void getCandidates_returnsMappedList() {
+        RankedCandidateRow row = mock(RankedCandidateRow.class);
+        when(row.getUser_id()).thenReturn(2L);
+        when(row.getDistance_km()).thenReturn(3.5);
+        when(row.getScore()).thenReturn(10);
+
+        when(userService.getCurrentUserEntity()).thenReturn(currentUser);
+        when(userRepository.findRankedCandidates(eq(1L), eq(point), eq(25000.0), eq(5)))
+                .thenReturn(List.of(row));
+        when(userRepository.findAllById(List.of(2L))).thenReturn(List.of(targetUser));
+
+        PublicUserResponse pub = new PublicUserResponse();
+        pub.setId(2L);
+        pub.setUsername("bob");
+        pub.setBio("bio");
+        pub.setGender(UserGender.MALE);
+        pub.setProfilePhotoUrl("pic");
+        pub.setLanguages(Set.of("en"));
+        pub.setDogs(List.of());
+        when(userMapper.toPublicUserResponse(targetUser)).thenReturn(pub);
+
+        List<CandidateUserResponse> result = matchService.getCandidates(5,25);
+        assertEquals(1, result.size());
+        CandidateUserResponse r = result.get(0);
+        assertEquals(2L, r.getId());
+        assertEquals("bob", r.getUsername());
+        assertEquals(3.5, r.getDistanceKm());
+        assertEquals(10, r.getScore());
+    }
+
+    @Test
+    void swipe_existingSwipeThrows() {
+        SwipeCreateRequest req = new SwipeCreateRequest(2L, SwipeDecision.LIKE);
+        when(userService.getCurrentUserEntity()).thenReturn(currentUser);
+        when(swipeRepository.existsByLikerIdAndTargetId(1L,2L)).thenReturn(true);
+        assertThrows(IllegalStateException.class, () -> matchService.swipe(req));
+        verify(swipeRepository, never()).save(any());
+    }
+
+    @Test
+    void swipe_passCreatesSwipeOnly() {
+        SwipeCreateRequest req = new SwipeCreateRequest(2L, SwipeDecision.PASS);
+        when(userService.getCurrentUserEntity()).thenReturn(currentUser);
+        when(swipeRepository.existsByLikerIdAndTargetId(1L,2L)).thenReturn(false);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(targetUser));
+
+        matchService.swipe(req);
+
+        verify(swipeRepository).save(any(Swipe.class));
+        verify(matchRepository, never()).save(any());
+    }
+
+    @Test
+    void swipe_likeCreatesMatchWhenReciprocal() {
+        SwipeCreateRequest req = new SwipeCreateRequest(2L, SwipeDecision.LIKE);
+        when(userService.getCurrentUserEntity()).thenReturn(currentUser);
+        when(swipeRepository.existsByLikerIdAndTargetId(1L,2L)).thenReturn(false);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(targetUser));
+        when(swipeRepository.findByLikerIdAndTargetIdAndDecision(2L,1L, SwipeDecision.LIKE))
+                .thenReturn(Optional.of(new Swipe()));
+        when(matchRepository.matchExists(1L,2L)).thenReturn(false);
+
+        matchService.swipe(req);
+
+        verify(matchRepository).save(any(Match.class));
+    }
+
+    @Test
+    void swipe_targetNotFound() {
+        SwipeCreateRequest req = new SwipeCreateRequest(2L, SwipeDecision.LIKE);
+        when(userService.getCurrentUserEntity()).thenReturn(currentUser);
+        when(swipeRepository.existsByLikerIdAndTargetId(1L,2L)).thenReturn(false);
+        when(userRepository.findById(2L)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () -> matchService.swipe(req));
+    }
+}


### PR DESCRIPTION
## Summary
- add `MatchServiceTest` covering service logic
- add `MatchControllerTest` for controller endpoints

## Testing
- `mvn -q test` *(fails: Connection to localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_683f8d5a824883239cf931b762bfa5de