### PR TITLE
Add chat access control and history API

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,15 @@
 - 🔧 Active Development *(MVP phase)*
 - 🧪 Modules in progress: swipe, chat, events
 - 🎯 Main focus: mobile app + RESTful backend
+
+## WebSocket API
+
+The backend exposes a STOMP endpoint at `/ws-chat`. The handshake requires a valid JWT,
+so include the token in the `Authorization` header (or cookie) when connecting
+with a WebSocket or SockJS client.
+
+### Endpoints
+
+- Chats are automatically created when two users match.
+- `/app/chat.send` – send a message to a chat; messages appear on `/topic/chats/{chatId}`.
+- `GET /api/chats/{chatId}/messages` – retrieve chat history paged by `page` and `limit`.

--- a/backend/src/main/java/com/pawconnect/backend/chat/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.pawconnect.backend.chat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-chat").setAllowedOriginPatterns("*");
+        registry.addEndpoint("/ws-chat").setAllowedOriginPatterns("*").withSockJS();
+    }
+}

--- a/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatController.java
@@ -1,0 +1,23 @@
+package com.pawconnect.backend.chat.controller;
+
+import com.pawconnect.backend.chat.dto.ChatMessageRequest;
+import com.pawconnect.backend.chat.dto.ChatMessageResponse;
+import com.pawconnect.backend.chat.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final MessageService messageService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/chat.send")
+    public void sendMessage(ChatMessageRequest request) {
+        ChatMessageResponse msg = messageService.saveMessage(request);
+        messagingTemplate.convertAndSend("/topic/chats/" + msg.getChatId(), msg);
+    }
+}

--- a/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatRestController.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatRestController.java
@@ -1,0 +1,27 @@
+package com.pawconnect.backend.chat.controller;
+
+import com.pawconnect.backend.chat.dto.ChatMessageResponse;
+import com.pawconnect.backend.chat.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/chats")
+@RequiredArgsConstructor
+@Validated
+public class ChatRestController {
+
+    private final MessageService messageService;
+
+    @GetMapping("/{chatId}/messages")
+    public ResponseEntity<List<ChatMessageResponse>> getMessages(
+            @PathVariable Long chatId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int limit) {
+        return ResponseEntity.ok(messageService.getMessages(chatId, page, limit));
+    }
+}

--- a/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatCreateRequest.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatCreateRequest.java
@@ -1,0 +1,13 @@
+package com.pawconnect.backend.chat.dto;
+
+import com.pawconnect.backend.common.enums.ChatType;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ChatCreateRequest {
+    private ChatType type;
+    private List<Long> participantIds;
+    private Long eventId;
+}

--- a/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatMapper.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatMapper.java
@@ -1,0 +1,22 @@
+package com.pawconnect.backend.chat.dto;
+
+import com.pawconnect.backend.chat.model.Chat;
+import com.pawconnect.backend.chat.model.ChatParticipant;
+import org.mapstruct.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Mapper(componentModel = "spring")
+public interface ChatMapper {
+    Chat toEntity(ChatCreateRequest request);
+
+    @Mapping(source = "event.id", target = "eventId")
+    @Mapping(target = "participantIds", expression = "java(mapParticipants(chat.getParticipants()))")
+    ChatResponse toDto(Chat chat);
+
+    default List<Long> mapParticipants(List<ChatParticipant> participants) {
+        if (participants == null) return List.of();
+        return participants.stream().map(p -> p.getUser().getId()).collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatMessageRequest.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatMessageRequest.java
@@ -1,0 +1,9 @@
+package com.pawconnect.backend.chat.dto;
+
+import lombok.Data;
+
+@Data
+public class ChatMessageRequest {
+    private Long chatId;
+    private String content;
+}

--- a/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatMessageResponse.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,14 @@
+package com.pawconnect.backend.chat.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ChatMessageResponse {
+    private Long id;
+    private Long chatId;
+    private Long senderId;
+    private String content;
+    private LocalDateTime timestamp;
+}

--- a/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatResponse.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatResponse.java
@@ -1,0 +1,14 @@
+package com.pawconnect.backend.chat.dto;
+
+import com.pawconnect.backend.common.enums.ChatType;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ChatResponse {
+    private Long id;
+    private ChatType type;
+    private Long eventId;
+    private List<Long> participantIds;
+}

--- a/backend/src/main/java/com/pawconnect/backend/chat/repository/ChatRepository.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/repository/ChatRepository.java
@@ -1,0 +1,10 @@
+package com.pawconnect.backend.chat.repository;
+
+import com.pawconnect.backend.chat.model.Chat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+    boolean existsByIdAndParticipantsUserId(Long id, Long userId);
+}

--- a/backend/src/main/java/com/pawconnect/backend/chat/repository/MessageRepository.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/repository/MessageRepository.java
@@ -1,0 +1,12 @@
+package com.pawconnect.backend.chat.repository;
+
+import com.pawconnect.backend.chat.model.Message;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MessageRepository extends JpaRepository<Message, Long> {
+    Page<Message> findByChatIdOrderByTimestampDesc(Long chatId, Pageable pageable);
+}

--- a/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
@@ -1,0 +1,63 @@
+package com.pawconnect.backend.chat.service;
+
+import com.pawconnect.backend.chat.dto.ChatCreateRequest;
+import com.pawconnect.backend.chat.dto.ChatMapper;
+import com.pawconnect.backend.chat.dto.ChatResponse;
+import com.pawconnect.backend.chat.model.Chat;
+import com.pawconnect.backend.chat.model.ChatParticipant;
+import com.pawconnect.backend.chat.repository.ChatRepository;
+import com.pawconnect.backend.common.exception.NotFoundException;
+import com.pawconnect.backend.common.exception.UnauthorizedAccessException;
+import com.pawconnect.backend.common.enums.ChatType;
+import com.pawconnect.backend.user.model.User;
+import com.pawconnect.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRepository chatRepository;
+    private final UserRepository userRepository;
+    private final ChatMapper chatMapper;
+
+    public ChatResponse createChat(ChatCreateRequest request) {
+        Chat chat = chatMapper.toEntity(request);
+        chat.setParticipants(new ArrayList<>());
+
+        List<User> users = userRepository.findAllById(request.getParticipantIds());
+        if (users.size() != request.getParticipantIds().size()) {
+            throw new NotFoundException("One or more users not found");
+        }
+        for (User u : users) {
+            chat.getParticipants().add(ChatParticipant.builder().chat(chat).user(u).build());
+        }
+        return chatMapper.toDto(chatRepository.save(chat));
+    }
+
+    public Chat createPrivateChat(User u1, User u2) {
+        Chat chat = Chat.builder()
+                .type(ChatType.PRIVATE)
+                .participants(new ArrayList<>())
+                .build();
+        chat.getParticipants().add(ChatParticipant.builder().chat(chat).user(u1).build());
+        chat.getParticipants().add(ChatParticipant.builder().chat(chat).user(u2).build());
+        return chatRepository.save(chat);
+    }
+
+    public Chat getChatEntity(Long id) {
+        return chatRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Chat not found"));
+    }
+
+    public Chat getChatForUser(Long chatId, Long userId) {
+        if (!chatRepository.existsByIdAndParticipantsUserId(chatId, userId)) {
+            throw new UnauthorizedAccessException("You are not a participant of this chat");
+        }
+        return getChatEntity(chatId);
+    }
+}

--- a/backend/src/main/java/com/pawconnect/backend/chat/service/MessageService.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/service/MessageService.java
@@ -1,0 +1,76 @@
+package com.pawconnect.backend.chat.service;
+
+import com.pawconnect.backend.chat.dto.ChatMessageRequest;
+import com.pawconnect.backend.chat.dto.ChatMessageResponse;
+import com.pawconnect.backend.chat.model.Chat;
+import com.pawconnect.backend.chat.model.Message;
+import com.pawconnect.backend.chat.repository.ChatRepository;
+import com.pawconnect.backend.chat.repository.MessageRepository;
+import com.pawconnect.backend.common.exception.NotFoundException;
+import com.pawconnect.backend.common.exception.UnauthorizedAccessException;
+import com.pawconnect.backend.user.model.User;
+import com.pawconnect.backend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+    private final MessageRepository messageRepository;
+    private final ChatRepository chatRepository;
+    private final UserService userService;
+
+    public ChatMessageResponse saveMessage(ChatMessageRequest request) {
+        Chat chat = chatRepository.findById(request.getChatId())
+                .orElseThrow(() -> new NotFoundException("Chat not found"));
+        User sender = userService.getCurrentUserEntity();
+
+        if (!chatRepository.existsByIdAndParticipantsUserId(chat.getId(), sender.getId())) {
+            throw new UnauthorizedAccessException("You are not a participant of this chat");
+        }
+
+        Message message = Message.builder()
+                .chat(chat)
+                .sender(sender)
+                .content(request.getContent())
+                .build();
+        Message saved = messageRepository.save(message);
+
+        ChatMessageResponse res = new ChatMessageResponse();
+        res.setId(saved.getId());
+        res.setChatId(chat.getId());
+        res.setSenderId(sender.getId());
+        res.setContent(saved.getContent());
+        res.setTimestamp(saved.getTimestamp());
+        return res;
+    }
+
+    public List<ChatMessageResponse> getMessages(Long chatId, int page, int limit) {
+        Chat chat = chatRepository.findById(chatId)
+                .orElseThrow(() -> new NotFoundException("Chat not found"));
+        User user = userService.getCurrentUserEntity();
+
+        if (!chatRepository.existsByIdAndParticipantsUserId(chat.getId(), user.getId())) {
+            throw new UnauthorizedAccessException("You are not a participant of this chat");
+        }
+
+        Pageable pageable = PageRequest.of(page, limit);
+        return messageRepository.findByChatIdOrderByTimestampDesc(chatId, pageable)
+                .stream()
+                .map(m -> {
+                    ChatMessageResponse dto = new ChatMessageResponse();
+                    dto.setId(m.getId());
+                    dto.setChatId(chatId);
+                    dto.setSenderId(m.getSender().getId());
+                    dto.setContent(m.getContent());
+                    dto.setTimestamp(m.getTimestamp());
+                    return dto;
+                })
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/pawconnect/backend/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/pawconnect/backend/config/WebSecurityConfig.java
@@ -67,6 +67,7 @@ public class WebSecurityConfig  {
                         auth.requestMatchers("/api/auth/**").permitAll()
                                 .requestMatchers("/swagger-ui/**").permitAll()
                                 .requestMatchers("/v3/**").permitAll()
+                                .requestMatchers("/ws-chat/**", "/ws-chat").authenticated()
                                 .anyRequest().authenticated()
                 );
 

--- a/backend/src/main/java/com/pawconnect/backend/match/service/MatchService.java
+++ b/backend/src/main/java/com/pawconnect/backend/match/service/MatchService.java
@@ -5,6 +5,7 @@ import com.pawconnect.backend.common.enums.SwipeDecision;
 import com.pawconnect.backend.match.dto.CandidateUserResponse;
 import com.pawconnect.backend.match.dto.RankedCandidateRow;
 import com.pawconnect.backend.match.dto.SwipeCreateRequest;
+import com.pawconnect.backend.chat.service.ChatService;
 import com.pawconnect.backend.match.model.Match;
 import com.pawconnect.backend.match.model.Swipe;
 import com.pawconnect.backend.match.repository.MatchRepository;
@@ -34,6 +35,7 @@ public class MatchService {
     private final UserRepository userRepository;
     private final UserService userService;
     private final UserMapper userMapper;
+    private final ChatService chatService;
 
     public List<CandidateUserResponse> getCandidates(int limit, double radiusKm) {
         User currentUser = userService.getCurrentUserEntity();
@@ -97,6 +99,7 @@ public class MatchService {
                     .user2(u2)
                     .createdAt(LocalDateTime.now())
                     .build());
+            chatService.createPrivateChat(u1, u2);
         }
     }
 

--- a/backend/src/test/java/com/pawconnect/backend/chat/controller/ChatControllerTest.java
+++ b/backend/src/test/java/com/pawconnect/backend/chat/controller/ChatControllerTest.java
@@ -1,0 +1,35 @@
+package com.pawconnect.backend.chat.controller;
+
+import com.pawconnect.backend.chat.dto.ChatMessageRequest;
+import com.pawconnect.backend.chat.dto.ChatMessageResponse;
+import com.pawconnect.backend.chat.service.MessageService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatControllerTest {
+
+    @Mock MessageService messageService;
+    @Mock SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks ChatController chatController;
+
+    @Test
+    void sendMessage_sendsToChatTopic() {
+        ChatMessageRequest req = new ChatMessageRequest();
+        req.setChatId(5L);
+        ChatMessageResponse resp = new ChatMessageResponse();
+        resp.setChatId(5L);
+        when(messageService.saveMessage(req)).thenReturn(resp);
+
+        chatController.sendMessage(req);
+
+        verify(messagingTemplate).convertAndSend("/topic/chats/5", resp);
+    }
+}

--- a/backend/src/test/java/com/pawconnect/backend/chat/service/ChatServiceTest.java
+++ b/backend/src/test/java/com/pawconnect/backend/chat/service/ChatServiceTest.java
@@ -1,0 +1,86 @@
+package com.pawconnect.backend.chat.service;
+
+import com.pawconnect.backend.chat.dto.ChatCreateRequest;
+import com.pawconnect.backend.chat.dto.ChatMapper;
+import com.pawconnect.backend.chat.dto.ChatResponse;
+import com.pawconnect.backend.chat.model.Chat;
+import com.pawconnect.backend.chat.repository.ChatRepository;
+import com.pawconnect.backend.common.enums.ChatType;
+import com.pawconnect.backend.common.exception.NotFoundException;
+import com.pawconnect.backend.user.model.User;
+import com.pawconnect.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceTest {
+
+    @Mock ChatRepository chatRepository;
+    @Mock UserRepository userRepository;
+    @Mock ChatMapper chatMapper;
+
+    @InjectMocks ChatService chatService;
+
+    private ChatCreateRequest request;
+    private Chat chat;
+    private ChatResponse response;
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        request = new ChatCreateRequest();
+        request.setType(ChatType.PRIVATE);
+        request.setParticipantIds(List.of(1L,2L));
+
+        chat = Chat.builder().id(10L).build();
+        response = new ChatResponse();
+        response.setId(10L);
+
+        user1 = User.builder().id(1L).build();
+        user2 = User.builder().id(2L).build();
+    }
+
+    @Test
+    void createChat_success() {
+        when(chatMapper.toEntity(request)).thenReturn(chat);
+        when(userRepository.findAllById(List.of(1L,2L))).thenReturn(List.of(user1,user2));
+        when(chatRepository.save(chat)).thenReturn(chat);
+        when(chatMapper.toDto(chat)).thenReturn(response);
+
+        ChatResponse res = chatService.createChat(request);
+        assertEquals(10L, res.getId());
+        verify(chatRepository).save(chat);
+    }
+
+    @Test
+    void createChat_userMissing() {
+        when(chatMapper.toEntity(request)).thenReturn(chat);
+        when(userRepository.findAllById(any())).thenReturn(List.of(user1));
+        assertThrows(NotFoundException.class, () -> chatService.createChat(request));
+    }
+
+    @Test
+    void getChatEntity_found() {
+        when(chatRepository.findById(10L)).thenReturn(Optional.of(chat));
+        Chat result = chatService.getChatEntity(10L);
+        assertEquals(chat, result);
+    }
+
+    @Test
+    void getChatEntity_notFound() {
+        when(chatRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThrows(NotFoundException.class, () -> chatService.getChatEntity(99L));
+    }
+}

--- a/backend/src/test/java/com/pawconnect/backend/match/service/MatchServiceTest.java
+++ b/backend/src/test/java/com/pawconnect/backend/match/service/MatchServiceTest.java
@@ -8,6 +8,7 @@ import com.pawconnect.backend.match.model.Match;
 import com.pawconnect.backend.match.model.Swipe;
 import com.pawconnect.backend.match.repository.MatchRepository;
 import com.pawconnect.backend.match.repository.SwipeRepository;
+import com.pawconnect.backend.chat.service.ChatService;
 import com.pawconnect.backend.user.dto.PublicUserResponse;
 import com.pawconnect.backend.user.dto.UserMapper;
 import com.pawconnect.backend.user.model.User;
@@ -42,6 +43,8 @@ class MatchServiceTest {
     private UserService userService;
     @Mock
     private UserMapper userMapper;
+    @Mock
+    private ChatService chatService;
 
     @InjectMocks
     private MatchService matchService;
@@ -123,6 +126,7 @@ class MatchServiceTest {
         matchService.swipe(req);
 
         verify(matchRepository).save(any(Match.class));
+        verify(chatService).createPrivateChat(currentUser, targetUser);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- secure `/ws-chat` endpoint by requiring JWT authentication
- restrict message sending to chat participants only
- implement paginated chat history retrieval
- document new REST endpoint and auth requirement

## Testing
- No tests run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68404bfc447083239ab6607e101cf003