### PR TITLE
Add service/controller for listing current user chats

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatRestController.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatRestController.java
@@ -1,7 +1,9 @@
 package com.pawconnect.backend.chat.controller;
 
 import com.pawconnect.backend.chat.dto.ChatMessageResponse;
+import com.pawconnect.backend.chat.dto.ChatResponse;
 import com.pawconnect.backend.chat.service.MessageService;
+import com.pawconnect.backend.chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -16,6 +18,12 @@ import java.util.List;
 public class ChatRestController {
 
     private final MessageService messageService;
+    private final ChatService chatService;
+
+    @GetMapping
+    public ResponseEntity<List<ChatResponse>> getCurrentUserChats() {
+        return ResponseEntity.ok(chatService.getCurrentUserChats());
+    }
 
     @GetMapping("/{chatId}/messages")
     public ResponseEntity<List<ChatMessageResponse>> getMessages(

--- a/backend/src/main/java/com/pawconnect/backend/chat/repository/ChatRepository.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/repository/ChatRepository.java
@@ -3,8 +3,11 @@ package com.pawconnect.backend.chat.repository;
 import com.pawconnect.backend.chat.model.Chat;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
 @Repository
 public interface ChatRepository extends JpaRepository<Chat, Long> {
     boolean existsByIdAndParticipantsUserId(Long id, Long userId);
+
+    List<Chat> findByParticipantsUserId(Long userId);
 }

--- a/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
@@ -11,6 +11,7 @@ import com.pawconnect.backend.common.exception.UnauthorizedAccessException;
 import com.pawconnect.backend.common.enums.ChatType;
 import com.pawconnect.backend.user.model.User;
 import com.pawconnect.backend.user.repository.UserRepository;
+import com.pawconnect.backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +25,7 @@ public class ChatService {
     private final ChatRepository chatRepository;
     private final UserRepository userRepository;
     private final ChatMapper chatMapper;
+    private final UserService userService;
 
     public ChatResponse createChat(ChatCreateRequest request) {
         Chat chat = chatMapper.toEntity(request);
@@ -59,5 +61,17 @@ public class ChatService {
             throw new UnauthorizedAccessException("You are not a participant of this chat");
         }
         return getChatEntity(chatId);
+    }
+
+    public List<ChatResponse> getCurrentUserChats() {
+        Long userId = userService.getCurrentUserEntity().getId();
+        return getChatsByUserId(userId);
+    }
+
+    public List<ChatResponse> getChatsByUserId(Long userId) {
+        return chatRepository.findByParticipantsUserId(userId)
+                .stream()
+                .map(chatMapper::toDto)
+                .toList();
     }
 }


### PR DESCRIPTION
## Summary
- remove `UserChatsService` and its controller
- add listing methods to `ChatService`
- expose `/api/chats` GET endpoint in `ChatRestController`

## Testing
- *(none specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841bef853988323bf3f4db8cb74e757