### PR TITLE
Add event chat lookup

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/chat/repository/ChatRepository.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/repository/ChatRepository.java
@@ -4,10 +4,13 @@ import com.pawconnect.backend.chat.model.Chat;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChatRepository extends JpaRepository<Chat, Long> {
     boolean existsByIdAndParticipantsUserId(Long id, Long userId);
 
     List<Chat> findByParticipantsUserId(Long userId);
+
+    Optional<Chat> findByEventId(Long eventId);
 }

--- a/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
@@ -102,4 +102,9 @@ public class ChatService {
                 .map(chatMapper::toDto)
                 .toList();
     }
+
+    public Chat getChatByEventId(Long eventId) {
+        return chatRepository.findByEventId(eventId)
+                .orElseThrow(() -> new NotFoundException("Chat not found"));
+    }
 }


### PR DESCRIPTION
## Summary
- add a lookup method for chats by event in `ChatRepository`
- expose chat lookup by event in `ChatService`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841d402ccc08323808d8c498eeb824a