### PR TITLE
Link event lifecycle with chats

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
@@ -66,6 +66,10 @@ public class ChatService {
         chatParticipantRepository.deleteByChatIdAndUserId(chat.getId(), user.getId());
     }
 
+    public void deleteChat(Chat chat) {
+        chatRepository.delete(chat);
+    }
+
     public Chat createGroupChatForEvent(com.pawconnect.backend.event.model.Event event) {
         Chat chat = Chat.builder()
                 .type(ChatType.GROUP)


### PR DESCRIPTION
## Summary
- connect events and chats via `ChatService`
- add participants to chat when joining events
- remove participants and delete chat when leaving or deleting events

## Testing
- `mvnw -q -DskipTests package` *(fails: failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842730acdf48323bd0e5b192667a072