### PR TITLE
Prevent host from joining their own event

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/event/service/EventService.java
+++ b/backend/src/main/java/com/pawconnect/backend/event/service/EventService.java
@@ -69,6 +69,9 @@ public class EventService {
     public void joinEvent(Long id, EventParticipantStatus status) {
         Event event = getEventEntity(id);
         User user = userService.getCurrentUserEntity();
+        if (event.getHost().getId().equals(user.getId())) {
+            throw new IllegalStateException("Host cannot join their own event");
+        }
         if (!participantRepository.existsByEventIdAndUserId(id, user.getId())) {
             EventParticipant participant = EventParticipant.builder()
                     .event(event)


### PR DESCRIPTION
## Summary
- block event hosts from joining their own events

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842765a9de08323b7c33a6cec8511cd