### PR TITLE
Fix leaving event when user not participant

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/event/service/EventService.java
+++ b/backend/src/main/java/com/pawconnect/backend/event/service/EventService.java
@@ -83,10 +83,13 @@ public class EventService {
 
     public void leaveEvent(Long id) {
         Long userId = SecurityUtils.getCurrentUserId();
-        participantRepository.deleteByEventIdAndUserId(id, userId);
-        User user = userService.getCurrentUserEntity();
-        Chat chat = chatService.getChatByEventId(id);
-        chatService.removeParticipant(chat, user);
+        boolean wasParticipant = participantRepository.existsByEventIdAndUserId(id, userId);
+        if (wasParticipant) {
+            participantRepository.deleteByEventIdAndUserId(id, userId);
+            User user = userService.getCurrentUserEntity();
+            Chat chat = chatService.getChatByEventId(id);
+            chatService.removeParticipant(chat, user);
+        }
     }
 
     public void deleteEvent(Long id) {


### PR DESCRIPTION
## Summary
- verify user participation before deleting and removing them from event

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_68427667fa7c8323b3ba847ef3a50c3e