### PR TITLE
Implement basic auth flow

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2,5 +2,5 @@ import 'package:flutter/material.dart';
 import 'src/app.dart';
 
 void main() {
-  runApp(const App());
+  runApp(App());
 }

--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -1,16 +1,37 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'features/auth/presentation/login_screen.dart';
+import 'features/auth/presentation/signup_screen.dart';
 
 class App extends StatelessWidget {
-  const App({super.key});
+  App({super.key});
+
+  final GoRouter _router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => const LoginScreen(),
+      ),
+      GoRoute(
+        path: '/signup',
+        builder: (context, state) => const SignupScreen(),
+      ),
+      GoRoute(
+        path: '/home',
+        builder: (context, state) => const MyHomePage(title: 'Home'),
+      ),
+    ],
+  );
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
+    return MaterialApp.router(
+      title: 'PawConnect',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      routerConfig: _router,
     );
   }
 }

--- a/mobile/lib/src/features/auth/presentation/login_screen.dart
+++ b/mobile/lib/src/features/auth/presentation/login_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../services/auth_service.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _loading = false;
+
+  Future<void> _signIn() async {
+    setState(() => _loading = true);
+    try {
+      await AuthService.instance
+          .signIn(_usernameController.text, _passwordController.text);
+      if (mounted) {
+        context.go('/home');
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Login failed: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('PawConnect')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _loading ? null : _signIn,
+              child: _loading
+                  ? const CircularProgressIndicator()
+                  : const Text('Sign in'),
+            ),
+            TextButton(
+              onPressed: () => context.push('/signup'),
+              child: const Text("Don't have an account? Sign up"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/features/auth/presentation/signup_screen.dart
+++ b/mobile/lib/src/features/auth/presentation/signup_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../services/auth_service.dart';
+
+class SignupScreen extends StatefulWidget {
+  const SignupScreen({super.key});
+
+  @override
+  State<SignupScreen> createState() => _SignupScreenState();
+}
+
+class _SignupScreenState extends State<SignupScreen> {
+  final TextEditingController _usernameController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  bool _loading = false;
+
+  Future<void> _register() async {
+    setState(() => _loading = true);
+    try {
+      await AuthService.instance.signUp(
+        _usernameController.text,
+        _emailController.text,
+        _passwordController.text,
+      );
+      if (mounted) {
+        context.go('/');
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Signup failed: $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _loading = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _loading ? null : _register,
+              child: _loading
+                  ? const CircularProgressIndicator()
+                  : const Text('Register'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/features/auth/services/auth_service.dart
+++ b/mobile/lib/src/features/auth/services/auth_service.dart
@@ -1,0 +1,27 @@
+import 'package:dio/dio.dart';
+
+class AuthService {
+  AuthService._();
+
+  static final AuthService instance = AuthService._();
+  final Dio _dio = Dio(BaseOptions(baseUrl: '/api/auth'));
+
+  Future<Response<dynamic>> signIn(String username, String password) {
+    return _dio.post('/signin', data: {
+      'username': username,
+      'password': password,
+    });
+  }
+
+  Future<Response<dynamic>> signUp(
+    String username,
+    String email,
+    String password,
+  ) {
+    return _dio.post('/signup', data: {
+      'username': username,
+      'email': email,
+      'password': password,
+    });
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  dio: ^5.4.0
+  go_router: ^13.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add login and signup screens
- implement AuthService using dio
- configure go_router navigation
- update main entrypoint to use new App
- add dio and go_router dependencies

## Testing
- `dart format mobile/lib/src/features/auth/presentation/login_screen.dart mobile/lib/src/features/auth/presentation/signup_screen.dart mobile/lib/src/features/auth/services/auth_service.dart mobile/lib/src/app.dart mobile/lib/main.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462d1d778c8323aaaa66b24e5941d9