### PR TITLE
Use env var for API base URL in Flutter client

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -26,7 +26,8 @@ The backend serves REST endpoints on `http://localhost:8080`.
 ```bash
 cd mobile
 flutter pub get
-flutter run
+flutter run --dart-define=API_BASE_URL=http://localhost:8080
 ```
 
-The app expects the backend to be reachable at `http://localhost:8080`.
+The app reads the API base URL from the `API_BASE_URL` environment variable.
+If not provided, it defaults to `http://localhost:8080`.

--- a/mobile/lib/src/env.dart
+++ b/mobile/lib/src/env.dart
@@ -1,0 +1,4 @@
+const String apiBaseUrl = String.fromEnvironment(
+  'API_BASE_URL',
+  defaultValue: 'http://localhost:8080',
+);

--- a/mobile/lib/src/features/auth/services/auth_service.dart
+++ b/mobile/lib/src/features/auth/services/auth_service.dart
@@ -1,10 +1,11 @@
 import 'package:dio/dio.dart';
+import '../../../env.dart';
 
 class AuthService {
   AuthService._();
 
   static final AuthService instance = AuthService._();
-  final Dio _dio = Dio(BaseOptions(baseUrl: '/api/auth'));
+  final Dio _dio = Dio(BaseOptions(baseUrl: '$apiBaseUrl/api/auth'));
 
   Future<Response<dynamic>> signIn(String username, String password) {
     return _dio.post('/signin', data: {


### PR DESCRIPTION
## Summary
- allow overriding API base URL via `API_BASE_URL` env var
- update mobile README with new instructions

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68463204a2688323ae1981b791f3ea0a