### PR TITLE
Improve auth error handling

### DIFF
--- a/mobile/lib/src/features/auth/presentation/login_screen.dart
+++ b/mobile/lib/src/features/auth/presentation/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:dio/dio.dart';
 import '../services/auth_service.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -22,10 +23,19 @@ class _LoginScreenState extends State<LoginScreen> {
       if (mounted) {
         context.go('/home');
       }
+    } on DioException catch (e) {
+      final message = e.response?.data['message'] ?? e.message;
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Login failed: $message')),
+        );
+      }
     } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Login failed: $e')),
-      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Login failed: $e')),
+        );
+      }
     } finally {
       if (mounted) {
         setState(() => _loading = false);

--- a/mobile/lib/src/features/auth/presentation/signup_screen.dart
+++ b/mobile/lib/src/features/auth/presentation/signup_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:dio/dio.dart';
 import '../services/auth_service.dart';
 
 class SignupScreen extends StatefulWidget {
@@ -26,10 +27,19 @@ class _SignupScreenState extends State<SignupScreen> {
       if (mounted) {
         context.go('/');
       }
+    } on DioException catch (e) {
+      final message = e.response?.data['message'] ?? e.message;
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Signup failed: $message')),
+        );
+      }
     } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Signup failed: $e')),
-      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Signup failed: $e')),
+        );
+      }
     } finally {
       if (mounted) {
         setState(() => _loading = false);


### PR DESCRIPTION
## Summary
- surface API error messages when logging in
- surface API error messages when signing up

## Testing
- `dart format -o none -l 120 lib/src/features/auth/presentation/login_screen.dart lib/src/features/auth/presentation/signup_screen.dart` *(fails: `bash: dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68463406ac0483239eb6c97121a1dd04