### PR TITLE
Add toggle to reveal password

### DIFF
--- a/mobile/lib/src/features/auth/presentation/login_screen.dart
+++ b/mobile/lib/src/features/auth/presentation/login_screen.dart
@@ -13,6 +13,7 @@ class LoginScreen extends StatefulWidget {
 class _LoginScreenState extends State<LoginScreen> {
   final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
+  bool _obscurePassword = true;
   bool _loading = false;
 
   Future<void> _signIn() async {
@@ -59,8 +60,22 @@ class _LoginScreenState extends State<LoginScreen> {
             const SizedBox(height: 12),
             TextField(
               controller: _passwordController,
-              decoration: const InputDecoration(labelText: 'Password'),
-              obscureText: true,
+              decoration: InputDecoration(
+                labelText: 'Password',
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscurePassword
+                        ? Icons.visibility
+                        : Icons.visibility_off,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      _obscurePassword = !_obscurePassword;
+                    });
+                  },
+                ),
+              ),
+              obscureText: _obscurePassword,
             ),
             const SizedBox(height: 24),
             ElevatedButton(

--- a/mobile/lib/src/features/auth/presentation/signup_screen.dart
+++ b/mobile/lib/src/features/auth/presentation/signup_screen.dart
@@ -14,6 +14,7 @@ class _SignupScreenState extends State<SignupScreen> {
   final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
+  bool _obscurePassword = true;
   bool _loading = false;
 
   Future<void> _register() async {
@@ -68,8 +69,22 @@ class _SignupScreenState extends State<SignupScreen> {
             const SizedBox(height: 12),
             TextField(
               controller: _passwordController,
-              decoration: const InputDecoration(labelText: 'Password'),
-              obscureText: true,
+              decoration: InputDecoration(
+                labelText: 'Password',
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscurePassword
+                        ? Icons.visibility
+                        : Icons.visibility_off,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      _obscurePassword = !_obscurePassword;
+                    });
+                  },
+                ),
+              ),
+              obscureText: _obscurePassword,
             ),
             const SizedBox(height: 24),
             ElevatedButton(


### PR DESCRIPTION
## Summary
- add eye icon to login screen password field
- add eye icon to signup screen password field

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684635d738a88323b38ab3d06a04ad7b