### PR TITLE
Add preference management and profile completion flow

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/user/controller/PreferenceController.java
+++ b/backend/src/main/java/com/pawconnect/backend/user/controller/PreferenceController.java
@@ -1,0 +1,28 @@
+package com.pawconnect.backend.user.controller;
+
+import com.pawconnect.backend.user.dto.PreferenceResponse;
+import com.pawconnect.backend.user.dto.PreferenceUpdateRequest;
+import com.pawconnect.backend.user.service.PreferenceService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/preferences")
+@RequiredArgsConstructor
+public class PreferenceController {
+
+    private final PreferenceService preferenceService;
+
+    @GetMapping("/current")
+    public ResponseEntity<PreferenceResponse> getCurrentPreferences() {
+        return ResponseEntity.ok(preferenceService.getCurrentPreference());
+    }
+
+    @PutMapping("/current")
+    public ResponseEntity<PreferenceResponse> updateCurrentPreferences(
+            @Valid @RequestBody PreferenceUpdateRequest request) {
+        return ResponseEntity.ok(preferenceService.updateCurrentPreference(request));
+    }
+}

--- a/backend/src/main/java/com/pawconnect/backend/user/dto/PreferenceMapper.java
+++ b/backend/src/main/java/com/pawconnect/backend/user/dto/PreferenceMapper.java
@@ -1,0 +1,15 @@
+package com.pawconnect.backend.user.dto;
+
+import com.pawconnect.backend.user.model.Preference;
+import org.mapstruct.*;
+
+@Mapper(componentModel = "spring")
+public interface PreferenceMapper {
+
+    PreferenceResponse toDto(Preference preference);
+
+    Preference toEntity(PreferenceUpdateRequest request);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void updatePreferenceFromDto(PreferenceUpdateRequest request, @MappingTarget Preference preference);
+}

--- a/backend/src/main/java/com/pawconnect/backend/user/dto/PreferenceResponse.java
+++ b/backend/src/main/java/com/pawconnect/backend/user/dto/PreferenceResponse.java
@@ -1,0 +1,15 @@
+package com.pawconnect.backend.user.dto;
+
+import com.pawconnect.backend.dog.model.ActivityLevel;
+import com.pawconnect.backend.dog.model.DogGender;
+import com.pawconnect.backend.dog.model.DogSize;
+import com.pawconnect.backend.dog.model.Personality;
+import lombok.Data;
+
+@Data
+public class PreferenceResponse {
+    private Personality preferredPersonality;
+    private ActivityLevel preferredActivityLevel;
+    private DogSize preferredSize;
+    private DogGender preferredGender;
+}

--- a/backend/src/main/java/com/pawconnect/backend/user/dto/PreferenceUpdateRequest.java
+++ b/backend/src/main/java/com/pawconnect/backend/user/dto/PreferenceUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.pawconnect.backend.user.dto;
+
+import com.pawconnect.backend.dog.model.ActivityLevel;
+import com.pawconnect.backend.dog.model.DogGender;
+import com.pawconnect.backend.dog.model.DogSize;
+import com.pawconnect.backend.dog.model.Personality;
+import lombok.Data;
+
+@Data
+public class PreferenceUpdateRequest {
+    private Personality preferredPersonality;
+    private ActivityLevel preferredActivityLevel;
+    private DogSize preferredSize;
+    private DogGender preferredGender;
+}

--- a/backend/src/main/java/com/pawconnect/backend/user/repository/PreferenceRepository.java
+++ b/backend/src/main/java/com/pawconnect/backend/user/repository/PreferenceRepository.java
@@ -1,0 +1,9 @@
+package com.pawconnect.backend.user.repository;
+
+import com.pawconnect.backend.user.model.Preference;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PreferenceRepository extends JpaRepository<Preference, Long> {
+}

--- a/backend/src/main/java/com/pawconnect/backend/user/service/PreferenceService.java
+++ b/backend/src/main/java/com/pawconnect/backend/user/service/PreferenceService.java
@@ -1,0 +1,43 @@
+package com.pawconnect.backend.user.service;
+
+import com.pawconnect.backend.user.dto.PreferenceMapper;
+import com.pawconnect.backend.user.dto.PreferenceResponse;
+import com.pawconnect.backend.user.dto.PreferenceUpdateRequest;
+import com.pawconnect.backend.user.model.Preference;
+import com.pawconnect.backend.user.model.User;
+import com.pawconnect.backend.user.repository.PreferenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PreferenceService {
+
+    private final PreferenceRepository preferenceRepository;
+    private final PreferenceMapper preferenceMapper;
+    private final UserService userService;
+
+    private Preference getOrCreatePreference(User user) {
+        return preferenceRepository.findById(user.getId())
+                .orElseGet(() -> preferenceRepository.save(
+                        Preference.builder().user(user).build()));
+    }
+
+    public PreferenceResponse getCurrentPreference() {
+        User user = userService.getCurrentUserEntity();
+        Preference pref = getOrCreatePreference(user);
+        return preferenceMapper.toDto(pref);
+    }
+
+    public PreferenceResponse updateCurrentPreference(PreferenceUpdateRequest request) {
+        User user = userService.getCurrentUserEntity();
+        Preference pref = getOrCreatePreference(user);
+        preferenceMapper.updatePreferenceFromDto(request, pref);
+        return preferenceMapper.toDto(preferenceRepository.save(pref));
+    }
+
+    public void deleteCurrentPreference() {
+        User user = userService.getCurrentUserEntity();
+        preferenceRepository.deleteById(user.getId());
+    }
+}

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -31,3 +31,9 @@ flutter run --dart-define=API_BASE_URL=http://localhost:8080
 
 The app reads the API base URL from the `API_BASE_URL` environment variable.
 If not provided, it defaults to `http://localhost:8080`.
+
+After signing in, the app automatically loads your profile and preferences.
+If any required information is missing you will be redirected to the
+multi‑step profile completion flow.  This wizard collects profile fields,
+preference settings and at least one dog entry before navigating to the home
+screen.

--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'features/auth/presentation/login_screen.dart';
 import 'features/auth/presentation/signup_screen.dart';
 import 'features/map/presentation/map_screen.dart';
+import 'features/profile/profile_completion_screen.dart';
 import 'styles/app_theme.dart';
 
 class App extends StatelessWidget {
@@ -22,6 +23,10 @@ class App extends StatelessWidget {
       GoRoute(
         path: '/home',
         builder: (context, state) => const MyHomePage(title: 'Home'),
+      ),
+      GoRoute(
+        path: '/profile/complete',
+        builder: (context, state) => const ProfileCompletionScreen(),
       ),
     ],
   );

--- a/mobile/lib/src/features/auth/presentation/login_screen.dart
+++ b/mobile/lib/src/features/auth/presentation/login_screen.dart
@@ -2,6 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:dio/dio.dart';
 import '../services/auth_service.dart';
+import '../../services/user_service.dart';
+import '../../services/preference_service.dart';
+import '../../services/completion_utils.dart';
+import '../../models/current_user_response.dart';
+import '../../models/preference_response.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -22,7 +27,15 @@ class _LoginScreenState extends State<LoginScreen> {
       await AuthService.instance
           .signIn(_usernameController.text, _passwordController.text);
       if (mounted) {
-        context.go('/home');
+        final userRes = await UserService.instance.getCurrentUser();
+        final prefRes = await PreferenceService.instance.getCurrent();
+        final user = CurrentUserResponse.fromJson(userRes.data);
+        final pref = PreferenceResponse.fromJson(prefRes.data);
+        if (isProfileComplete(user) && isPreferencesComplete(pref)) {
+          context.go('/home');
+        } else {
+          context.go('/profile/complete');
+        }
       }
     } on DioException catch (e) {
       final message = e.response?.data['message'] ?? e.message;

--- a/mobile/lib/src/features/profile/profile_completion_screen.dart
+++ b/mobile/lib/src/features/profile/profile_completion_screen.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../services/user_service.dart';
+import '../../services/preference_service.dart';
+import '../../services/dog_service.dart';
+
+class ProfileCompletionScreen extends StatefulWidget {
+  const ProfileCompletionScreen({super.key});
+
+  @override
+  State<ProfileCompletionScreen> createState() => _ProfileCompletionScreenState();
+}
+
+class _ProfileCompletionScreenState extends State<ProfileCompletionScreen> {
+  int _step = 0;
+  bool _loading = false;
+
+  final TextEditingController bioController = TextEditingController();
+  final TextEditingController birthdateController = TextEditingController();
+  String? gender;
+  final TextEditingController languagesController = TextEditingController();
+
+  String? prefActivity;
+  String? prefSize;
+  String? prefGender;
+  String? prefPersonality;
+
+  final TextEditingController dogNameController = TextEditingController();
+  final TextEditingController dogBreedController = TextEditingController();
+  final TextEditingController dogBirthdateController = TextEditingController();
+  String? dogGender;
+  String? dogSize;
+  String? dogPersonality;
+  String? dogActivity;
+
+  Future<void> _submit() async {
+    setState(() => _loading = true);
+    try {
+      await UserService.instance.updateCurrentUser({
+        'bio': bioController.text,
+        'birthdate': birthdateController.text,
+        'gender': gender,
+        'languageIds': languagesController.text
+            .split(',')
+            .where((e) => e.trim().isNotEmpty)
+            .map(int.parse)
+            .toList(),
+      });
+      await PreferenceService.instance.updateCurrent({
+        'preferredPersonality': prefPersonality,
+        'preferredActivityLevel': prefActivity,
+        'preferredSize': prefSize,
+        'preferredGender': prefGender,
+      });
+      await DogService.instance.createDog({
+        'name': dogNameController.text,
+        'breed': dogBreedController.text,
+        'birthdate': dogBirthdateController.text,
+        'size': dogSize,
+        'gender': dogGender,
+        'personality': dogPersonality,
+        'activityLevel': dogActivity,
+      });
+      if (mounted) context.go('/home');
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Complete Profile')),
+      body: Stepper(
+        currentStep: _step,
+        onStepContinue: () {
+          if (_step < 2) {
+            setState(() => _step += 1);
+          } else {
+            _submit();
+          }
+        },
+        onStepCancel: _step > 0 ? () => setState(() => _step -= 1) : null,
+        controlsBuilder: (context, details) {
+          return Row(
+            children: [
+              ElevatedButton(
+                onPressed: _loading ? null : details.onStepContinue,
+                child: _step == 2 ? const Text('Finish') : const Text('Next'),
+              ),
+              if (_step > 0)
+                TextButton(
+                  onPressed: details.onStepCancel,
+                  child: const Text('Back'),
+                ),
+            ],
+          );
+        },
+        steps: [
+          Step(
+            title: const Text('Profile'),
+            content: Column(
+              children: [
+                TextField(
+                  controller: bioController,
+                  decoration: const InputDecoration(labelText: 'Bio'),
+                ),
+                TextField(
+                  controller: birthdateController,
+                  decoration: const InputDecoration(labelText: 'Birthdate'),
+                ),
+                DropdownButtonFormField<String>(
+                  value: gender,
+                  items: const [
+                    DropdownMenuItem(value: 'MALE', child: Text('Male')),
+                    DropdownMenuItem(value: 'FEMALE', child: Text('Female')),
+                  ],
+                  onChanged: (v) => setState(() => gender = v),
+                  decoration: const InputDecoration(labelText: 'Gender'),
+                ),
+                TextField(
+                  controller: languagesController,
+                  decoration: const InputDecoration(
+                      labelText: 'Language IDs (comma separated)'),
+                ),
+              ],
+            ),
+          ),
+          Step(
+            title: const Text('Preferences'),
+            content: Column(
+              children: [
+                DropdownButtonFormField<String>(
+                  value: prefActivity,
+                  items: const [
+                    DropdownMenuItem(value: 'LOW', child: Text('Low')),
+                    DropdownMenuItem(value: 'MEDIUM', child: Text('Medium')),
+                    DropdownMenuItem(value: 'HIGH', child: Text('High')),
+                  ],
+                  onChanged: (v) => setState(() => prefActivity = v),
+                  decoration: const InputDecoration(labelText: 'Activity Level'),
+                ),
+                DropdownButtonFormField<String>(
+                  value: prefSize,
+                  items: const [
+                    DropdownMenuItem(value: 'SMALL', child: Text('Small')),
+                    DropdownMenuItem(value: 'MEDIUM', child: Text('Medium')),
+                    DropdownMenuItem(value: 'LARGE', child: Text('Large')),
+                  ],
+                  onChanged: (v) => setState(() => prefSize = v),
+                  decoration: const InputDecoration(labelText: 'Dog Size'),
+                ),
+                DropdownButtonFormField<String>(
+                  value: prefGender,
+                  items: const [
+                    DropdownMenuItem(value: 'MALE', child: Text('Male')),
+                    DropdownMenuItem(value: 'FEMALE', child: Text('Female')),
+                  ],
+                  onChanged: (v) => setState(() => prefGender = v),
+                  decoration: const InputDecoration(labelText: 'Dog Gender'),
+                ),
+                DropdownButtonFormField<String>(
+                  value: prefPersonality,
+                  items: const [
+                    DropdownMenuItem(value: 'CALM', child: Text('Calm')),
+                    DropdownMenuItem(value: 'PLAYFUL', child: Text('Playful')),
+                  ],
+                  onChanged: (v) => setState(() => prefPersonality = v),
+                  decoration: const InputDecoration(labelText: 'Personality'),
+                ),
+              ],
+            ),
+          ),
+          Step(
+            title: const Text('Your Dog'),
+            content: Column(
+              children: [
+                TextField(
+                  controller: dogNameController,
+                  decoration: const InputDecoration(labelText: 'Name'),
+                ),
+                TextField(
+                  controller: dogBreedController,
+                  decoration: const InputDecoration(labelText: 'Breed'),
+                ),
+                TextField(
+                  controller: dogBirthdateController,
+                  decoration: const InputDecoration(labelText: 'Birthdate'),
+                ),
+                DropdownButtonFormField<String>(
+                  value: dogSize,
+                  items: const [
+                    DropdownMenuItem(value: 'SMALL', child: Text('Small')),
+                    DropdownMenuItem(value: 'MEDIUM', child: Text('Medium')),
+                    DropdownMenuItem(value: 'LARGE', child: Text('Large')),
+                  ],
+                  onChanged: (v) => setState(() => dogSize = v),
+                  decoration: const InputDecoration(labelText: 'Size'),
+                ),
+                DropdownButtonFormField<String>(
+                  value: dogGender,
+                  items: const [
+                    DropdownMenuItem(value: 'MALE', child: Text('Male')),
+                    DropdownMenuItem(value: 'FEMALE', child: Text('Female')),
+                  ],
+                  onChanged: (v) => setState(() => dogGender = v),
+                  decoration: const InputDecoration(labelText: 'Gender'),
+                ),
+                DropdownButtonFormField<String>(
+                  value: dogPersonality,
+                  items: const [
+                    DropdownMenuItem(value: 'CALM', child: Text('Calm')),
+                    DropdownMenuItem(value: 'PLAYFUL', child: Text('Playful')),
+                  ],
+                  onChanged: (v) => setState(() => dogPersonality = v),
+                  decoration: const InputDecoration(labelText: 'Personality'),
+                ),
+                DropdownButtonFormField<String>(
+                  value: dogActivity,
+                  items: const [
+                    DropdownMenuItem(value: 'LOW', child: Text('Low')),
+                    DropdownMenuItem(value: 'MEDIUM', child: Text('Medium')),
+                    DropdownMenuItem(value: 'HIGH', child: Text('High')),
+                  ],
+                  onChanged: (v) => setState(() => dogActivity = v),
+                  decoration: const InputDecoration(labelText: 'Activity Level'),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/models/current_user_response.dart
+++ b/mobile/lib/src/models/current_user_response.dart
@@ -1,0 +1,28 @@
+class CurrentUserResponse {
+  final int id;
+  final String username;
+  final String email;
+  final String? bio;
+  final String? birthdate;
+  final String? gender;
+  final double latitude;
+  final double longitude;
+  final bool? locationVisible;
+  final String? profilePhotoUrl;
+  final List<String> languages;
+  final List<dynamic> dogs;
+
+  CurrentUserResponse.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        username = json['username'],
+        email = json['email'],
+        bio = json['bio'],
+        birthdate = json['birthdate'],
+        gender = json['gender'],
+        latitude = (json['latitude'] as num).toDouble(),
+        longitude = (json['longitude'] as num).toDouble(),
+        locationVisible = json['locationVisible'],
+        profilePhotoUrl = json['profilePhotoUrl'],
+        languages = List<String>.from(json['languages'] ?? []),
+        dogs = List<dynamic>.from(json['dogs'] ?? []);
+}

--- a/mobile/lib/src/models/preference_response.dart
+++ b/mobile/lib/src/models/preference_response.dart
@@ -1,0 +1,12 @@
+class PreferenceResponse {
+  final String? preferredPersonality;
+  final String? preferredActivityLevel;
+  final String? preferredSize;
+  final String? preferredGender;
+
+  PreferenceResponse.fromJson(Map<String, dynamic> json)
+      : preferredPersonality = json['preferredPersonality'],
+        preferredActivityLevel = json['preferredActivityLevel'],
+        preferredSize = json['preferredSize'],
+        preferredGender = json['preferredGender'];
+}

--- a/mobile/lib/src/services/completion_utils.dart
+++ b/mobile/lib/src/services/completion_utils.dart
@@ -1,0 +1,17 @@
+import '../models/current_user_response.dart';
+import '../models/preference_response.dart';
+
+bool isProfileComplete(CurrentUserResponse user) {
+  return user.bio != null &&
+      user.birthdate != null &&
+      user.gender != null &&
+      user.languages.isNotEmpty &&
+      user.dogs.isNotEmpty;
+}
+
+bool isPreferencesComplete(PreferenceResponse pref) {
+  return pref.preferredPersonality != null &&
+      pref.preferredActivityLevel != null &&
+      pref.preferredSize != null &&
+      pref.preferredGender != null;
+}

--- a/mobile/lib/src/services/dog_service.dart
+++ b/mobile/lib/src/services/dog_service.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import '../env.dart';
+
+class DogService {
+  DogService._();
+
+  static final DogService instance = DogService._();
+  final Dio _dio = Dio(BaseOptions(baseUrl: '$apiBaseUrl/api/dogs'));
+
+  Future<Response<dynamic>> createDog(Map<String, dynamic> data) {
+    return _dio.post('', data: data);
+  }
+
+  Future<Response<dynamic>> getDog(int id) {
+    return _dio.get('/$id');
+  }
+}

--- a/mobile/lib/src/services/preference_service.dart
+++ b/mobile/lib/src/services/preference_service.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import '../env.dart';
+
+class PreferenceService {
+  PreferenceService._();
+
+  static final PreferenceService instance = PreferenceService._();
+  final Dio _dio = Dio(BaseOptions(baseUrl: '$apiBaseUrl/api/preferences'));
+
+  Future<Response<dynamic>> getCurrent() {
+    return _dio.get('/current');
+  }
+
+  Future<Response<dynamic>> updateCurrent(Map<String, dynamic> data) {
+    return _dio.put('/current', data: data);
+  }
+}

--- a/mobile/lib/src/services/user_service.dart
+++ b/mobile/lib/src/services/user_service.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import '../env.dart';
+
+class UserService {
+  UserService._();
+
+  static final UserService instance = UserService._();
+  final Dio _dio = Dio(BaseOptions(baseUrl: '$apiBaseUrl/api/users'));
+
+  Future<Response<dynamic>> getCurrentUser() {
+    return _dio.get('/current');
+  }
+
+  Future<Response<dynamic>> updateCurrentUser(Map<String, dynamic> data) {
+    return _dio.put('/current', data: data);
+  }
+}


### PR DESCRIPTION
## Summary
- implement backend CRUD for user preferences and expose via `/api/preferences/current`
- add Flutter services for users and preferences
- introduce profile completion check and multi-step form
- update login flow to verify profile and preferences
- register `/profile/complete` route and document post-login verification

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68464176f2b0832398129242fdf3d51d