### PR TITLE
Use shared Dio with cookie support

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -32,6 +32,11 @@ flutter run --dart-define=API_BASE_URL=http://localhost:8080
 The app reads the API base URL from the `API_BASE_URL` environment variable.
 If not provided, it defaults to `http://localhost:8080`.
 
+All HTTP requests go through a shared `Dio` client defined in
+`lib/src/services/http_client.dart`. The client stores cookies with a
+`CookieJar` and uses a `CookieManager` interceptor so that the JWT cookie
+received during sign‑in is automatically included in subsequent API calls.
+
 After signing in, the app automatically loads your profile and preferences.
 If any required information is missing you will be redirected to the
 multi‑step profile completion flow.  This wizard collects profile fields,

--- a/mobile/lib/src/features/auth/services/auth_service.dart
+++ b/mobile/lib/src/features/auth/services/auth_service.dart
@@ -1,14 +1,15 @@
 import 'package:dio/dio.dart';
-import '../../../env.dart';
+
+import '../../../services/http_client.dart';
 
 class AuthService {
   AuthService._();
 
   static final AuthService instance = AuthService._();
-  final Dio _dio = Dio(BaseOptions(baseUrl: '$apiBaseUrl/api/auth'));
+  final Dio _dio = HttpClient.instance.dio;
 
   Future<Response<dynamic>> signIn(String username, String password) {
-    return _dio.post('/signin', data: {
+    return _dio.post('/auth/signin', data: {
       'username': username,
       'password': password,
     });
@@ -19,7 +20,7 @@ class AuthService {
     String email,
     String password,
   ) {
-    return _dio.post('/signup', data: {
+    return _dio.post('/auth/signup', data: {
       'username': username,
       'email': email,
       'password': password,

--- a/mobile/lib/src/services/dog_service.dart
+++ b/mobile/lib/src/services/dog_service.dart
@@ -1,17 +1,18 @@
 import 'package:dio/dio.dart';
-import '../env.dart';
+
+import 'http_client.dart';
 
 class DogService {
   DogService._();
 
   static final DogService instance = DogService._();
-  final Dio _dio = Dio(BaseOptions(baseUrl: '$apiBaseUrl/api/dogs'));
+  final Dio _dio = HttpClient.instance.dio;
 
   Future<Response<dynamic>> createDog(Map<String, dynamic> data) {
-    return _dio.post('', data: data);
+    return _dio.post('/dogs', data: data);
   }
 
   Future<Response<dynamic>> getDog(int id) {
-    return _dio.get('/$id');
+    return _dio.get('/dogs/$id');
   }
 }

--- a/mobile/lib/src/services/http_client.dart
+++ b/mobile/lib/src/services/http_client.dart
@@ -1,0 +1,21 @@
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:dio/dio.dart';
+import 'package:dio_cookie_manager/dio_cookie_manager.dart';
+
+import '../env.dart';
+
+class HttpClient {
+  HttpClient._() {
+    _dio = Dio(BaseOptions(baseUrl: '$apiBaseUrl/api'));
+    _cookieJar = CookieJar();
+    _dio.interceptors.add(CookieManager(_cookieJar));
+  }
+
+  static final HttpClient instance = HttpClient._();
+
+  late final Dio _dio;
+  late final CookieJar _cookieJar;
+
+  Dio get dio => _dio;
+}
+

--- a/mobile/lib/src/services/preference_service.dart
+++ b/mobile/lib/src/services/preference_service.dart
@@ -1,17 +1,18 @@
 import 'package:dio/dio.dart';
-import '../env.dart';
+
+import 'http_client.dart';
 
 class PreferenceService {
   PreferenceService._();
 
   static final PreferenceService instance = PreferenceService._();
-  final Dio _dio = Dio(BaseOptions(baseUrl: '$apiBaseUrl/api/preferences'));
+  final Dio _dio = HttpClient.instance.dio;
 
   Future<Response<dynamic>> getCurrent() {
-    return _dio.get('/current');
+    return _dio.get('/preferences/current');
   }
 
   Future<Response<dynamic>> updateCurrent(Map<String, dynamic> data) {
-    return _dio.put('/current', data: data);
+    return _dio.put('/preferences/current', data: data);
   }
 }

--- a/mobile/lib/src/services/user_service.dart
+++ b/mobile/lib/src/services/user_service.dart
@@ -1,17 +1,18 @@
 import 'package:dio/dio.dart';
-import '../env.dart';
+
+import 'http_client.dart';
 
 class UserService {
   UserService._();
 
   static final UserService instance = UserService._();
-  final Dio _dio = Dio(BaseOptions(baseUrl: '$apiBaseUrl/api/users'));
+  final Dio _dio = HttpClient.instance.dio;
 
   Future<Response<dynamic>> getCurrentUser() {
-    return _dio.get('/current');
+    return _dio.get('/users/current');
   }
 
   Future<Response<dynamic>> updateCurrentUser(Map<String, dynamic> data) {
-    return _dio.put('/current', data: data);
+    return _dio.put('/users/current', data: data);
   }
 }

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   dio: ^5.4.0
+  cookie_jar: ^3.0.1
+  dio_cookie_manager: ^3.0.0
   go_router: ^13.1.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add `cookie_jar` and `dio_cookie_manager` deps
- share a `Dio` client configured with `CookieJar`
- update services to use the shared client
- document cookie persistence in the README

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684646f44654832399127857686c732e