### PR TITLE
Add dog profile widgets and logout

### DIFF
--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -5,6 +5,7 @@ import 'features/auth/presentation/signup_screen.dart';
 import 'features/map/presentation/map_screen.dart';
 import 'features/profile/profile_completion_screen.dart';
 import 'features/profile/presentation/profile_screen.dart';
+import 'features/dog/presentation/dog_profile_screen.dart';
 import 'styles/app_theme.dart';
 
 class App extends StatelessWidget {
@@ -32,6 +33,14 @@ class App extends StatelessWidget {
       GoRoute(
         path: '/profile/complete',
         builder: (context, state) => const ProfileCompletionScreen(),
+      ),
+      GoRoute(
+        path: '/dogs/:id',
+        name: 'dog-profile',
+        builder: (context, state) {
+          final id = int.parse(state.pathParameters['id']!);
+          return DogProfileScreen(dogId: id);
+        },
       ),
     ],
   );

--- a/mobile/lib/src/features/dog/presentation/dog_card.dart
+++ b/mobile/lib/src/features/dog/presentation/dog_card.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import '../../../models/dog.dart';
+
+class DogCard extends StatelessWidget {
+  final Dog dog;
+  final VoidCallback? onTap;
+
+  const DogCard({super.key, required this.dog, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(12.0),
+          child: Row(
+            children: [
+              CircleAvatar(
+                radius: 24,
+                child: Text(dog.name.isNotEmpty ? dog.name[0] : '?'),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      dog.name,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    if (dog.breed != null)
+                      Text(
+                        dog.breed!,
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                  ],
+                ),
+              ),
+              const Icon(Icons.chevron_right),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/features/dog/presentation/dog_profile_screen.dart
+++ b/mobile/lib/src/features/dog/presentation/dog_profile_screen.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../../models/dog.dart';
+import '../../../services/dog_service.dart';
+
+class DogProfileScreen extends StatefulWidget {
+  final int dogId;
+
+  const DogProfileScreen({super.key, required this.dogId});
+
+  @override
+  State<DogProfileScreen> createState() => _DogProfileScreenState();
+}
+
+class _DogProfileScreenState extends State<DogProfileScreen> {
+  Dog? _dog;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDog();
+  }
+
+  Future<void> _loadDog() async {
+    setState(() => _loading = true);
+    try {
+      final res = await DogService.instance.getDog(widget.dogId);
+      _dog = Dog.fromJson(res.data);
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dog Profile')),
+      body: RefreshIndicator(
+        onRefresh: _loadDog,
+        child: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : _dog == null
+                ? const Center(child: Text('Failed to load dog'))
+                : SingleChildScrollView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Center(
+                          child: CircleAvatar(
+                            radius: 50,
+                            child: Text(
+                              _dog!.name.isNotEmpty ? _dog!.name[0] : '?',
+                              style: Theme.of(context).textTheme.headlineMedium,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        Text('Name: ${_dog!.name}'),
+                        if (_dog!.breed != null) ...[
+                          const SizedBox(height: 8),
+                          Text('Breed: ${_dog!.breed}'),
+                        ],
+                        if (_dog!.birthdate != null) ...[
+                          const SizedBox(height: 8),
+                          Text('Birthdate: ${_dog!.birthdate}'),
+                        ],
+                        if (_dog!.gender != null) ...[
+                          const SizedBox(height: 8),
+                          Text('Gender: ${_dog!.gender}'),
+                        ],
+                        if (_dog!.size != null) ...[
+                          const SizedBox(height: 8),
+                          Text('Size: ${_dog!.size}'),
+                        ],
+                        if (_dog!.personality != null) ...[
+                          const SizedBox(height: 8),
+                          Text('Personality: ${_dog!.personality}'),
+                        ],
+                        if (_dog!.activityLevel != null) ...[
+                          const SizedBox(height: 8),
+                          Text('Activity Level: ${_dog!.activityLevel}'),
+                        ],
+                      ],
+                    ),
+                  ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/features/profile/presentation/profile_screen.dart
+++ b/mobile/lib/src/features/profile/presentation/profile_screen.dart
@@ -2,7 +2,10 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import '../../../models/current_user_response.dart';
+import '../../../models/dog.dart';
 import '../../../services/user_service.dart';
+import '../../../services/http_client.dart';
+import '../../dog/presentation/dog_card.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
@@ -31,10 +34,20 @@ class _ProfileScreenState extends State<ProfileScreen> {
     }
   }
 
+  Future<void> _logout() async {
+    await HttpClient.instance.clearCookies();
+    if (mounted) context.go('/');
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Profile')),
+      appBar: AppBar(
+        title: const Text('Profile'),
+        actions: [
+          IconButton(onPressed: _logout, icon: const Icon(Icons.logout)),
+        ],
+      ),
       body: RefreshIndicator(
         onRefresh: _loadUser,
         child: _loading
@@ -44,9 +57,13 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 padding: const EdgeInsets.all(16),
                 child: _user == null
                     ? const Text('Failed to load profile')
-                    : Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
+                    : Card(
+                        margin: EdgeInsets.zero,
+                        child: Padding(
+                          padding: const EdgeInsets.all(16),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
                           Center(
                             child: CircleAvatar(
                               radius: 50,
@@ -57,7 +74,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                             ),
                           ),
                           const SizedBox(height: 16),
-                          Text('Username: ${_user!.username}'),
+                          Text(
+                            _user!.username,
+                            style: Theme.of(context).textTheme.headlineMedium,
+                          ),
                           const SizedBox(height: 8),
                           Text('Email: ${_user!.email}'),
                           if (_user!.bio != null) ...[
@@ -87,13 +107,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
                             const Text('No dogs added')
                           else
                             Column(
-                              children: _user!.dogs
-                                  .map<Widget>((dog) {
-                                final name = dog['name'] ?? 'Unnamed';
-                                final breed = dog['breed'];
-                                return ListTile(
-                                  title: Text(name),
-                                  subtitle: breed != null ? Text(breed) : null,
+                              children: _user!.dogs.map<Widget>((data) {
+                                final dog = Dog.fromJson(data);
+                                return DogCard(
+                                  dog: dog,
+                                  onTap: () => context.pushNamed(
+                                    'dog-profile',
+                                    pathParameters: {'id': dog.id.toString()},
+                                  ),
                                 );
                               }).toList(),
                             ),
@@ -106,7 +127,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
                           ),
                         ],
                       ),
-              ),
+                    ),
+                  ),
+        ),
       ),
     );
   }

--- a/mobile/lib/src/models/dog.dart
+++ b/mobile/lib/src/models/dog.dart
@@ -1,0 +1,34 @@
+class Dog {
+  final int id;
+  final String name;
+  final String? breed;
+  final String? birthdate;
+  final String? size;
+  final String? gender;
+  final String? personality;
+  final String? activityLevel;
+
+  Dog({
+    required this.id,
+    required this.name,
+    this.breed,
+    this.birthdate,
+    this.size,
+    this.gender,
+    this.personality,
+    this.activityLevel,
+  });
+
+  factory Dog.fromJson(Map<String, dynamic> json) {
+    return Dog(
+      id: json['id'],
+      name: json['name'] ?? 'Unnamed',
+      breed: json['breed'],
+      birthdate: json['birthdate'],
+      size: json['size'],
+      gender: json['gender'],
+      personality: json['personality'],
+      activityLevel: json['activityLevel'],
+    );
+  }
+}

--- a/mobile/lib/src/services/http_client.dart
+++ b/mobile/lib/src/services/http_client.dart
@@ -17,5 +17,9 @@ class HttpClient {
   late final CookieJar _cookieJar;
 
   Dio get dio => _dio;
+
+  Future<void> clearCookies() async {
+    await _cookieJar.deleteAll();
+  }
 }
 


### PR DESCRIPTION
## Summary
- add `DogCard` widget and `DogProfileScreen`
- enable logout via cookie clearing
- show list of dogs with cards in profile screen
- refactor profile UI styling
- route `/dogs/:id` to dog profile screen
- use named route to navigate to dog profile

## Testing
- ❌ `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847589bbd508323bf5c94627e0784fa