### PR TITLE
Add unified app bar with logo and logout

### DIFF
--- a/mobile/assets/logo.svg
+++ b/mobile/assets/logo.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="20" cy="20" r="10"/>
+  <circle cx="44" cy="20" r="10"/>
+  <circle cx="32" cy="40" r="12"/>
+  <circle cx="20" cy="44" r="6"/>
+  <circle cx="44" cy="44" r="6"/>
+</svg>

--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -3,6 +3,8 @@ import 'package:go_router/go_router.dart';
 import 'features/auth/presentation/login_screen.dart';
 import 'features/auth/presentation/signup_screen.dart';
 import 'features/map/presentation/map_screen.dart';
+import 'features/home/presentation/home_screen.dart';
+import 'features/chat/presentation/chat_screen.dart';
 import 'features/profile/profile_completion_screen.dart';
 import 'features/profile/presentation/profile_screen.dart';
 import 'features/dog/presentation/dog_profile_screen.dart';
@@ -65,9 +67,9 @@ class _MyHomePageState extends State<MyHomePage> {
   int _selectedIndex = 0;
 
   static final List<Widget> _pages = <Widget>[
-    const Center(child: Text('Home')),
+    const HomeScreen(),
     const MapScreen(),
-    const Center(child: Text('Chat')),
+    const ChatScreen(),
     const ProfileScreen(),
   ];
 

--- a/mobile/lib/src/features/chat/presentation/chat_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_screen.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import '../../../shared/main_app_bar.dart';
+
+class ChatScreen extends StatelessWidget {
+  const ChatScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: MainAppBar(title: 'Chat'),
+      body: Center(child: Text('Chat page placeholder')),
+    );
+  }
+}

--- a/mobile/lib/src/features/home/presentation/home_screen.dart
+++ b/mobile/lib/src/features/home/presentation/home_screen.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import '../../../shared/main_app_bar.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: MainAppBar(title: 'Home'),
+      body: Center(child: Text('Home page placeholder')),
+    );
+  }
+}

--- a/mobile/lib/src/features/map/presentation/map_screen.dart
+++ b/mobile/lib/src/features/map/presentation/map_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../../shared/main_app_bar.dart';
 
 class MapScreen extends StatefulWidget {
   const MapScreen({super.key});
@@ -11,6 +12,7 @@ class _MapScreenState extends State<MapScreen> {
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
+      appBar: MainAppBar(title: 'Map'),
       body: Center(
         child: Text('Map page placeholder'),
       ),

--- a/mobile/lib/src/features/profile/presentation/profile_screen.dart
+++ b/mobile/lib/src/features/profile/presentation/profile_screen.dart
@@ -1,11 +1,10 @@
-import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import '../../../models/current_user_response.dart';
 import '../../../models/dog.dart';
 import '../../../services/user_service.dart';
-import '../../../services/http_client.dart';
 import '../../dog/presentation/dog_card.dart';
+import '../../../shared/main_app_bar.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
@@ -34,20 +33,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
     }
   }
 
-  Future<void> _logout() async {
-    await HttpClient.instance.clearCookies();
-    if (mounted) context.go('/');
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Profile'),
-        actions: [
-          IconButton(onPressed: _logout, icon: const Icon(Icons.logout)),
-        ],
-      ),
+      appBar: const MainAppBar(title: 'Profile'),
       body: RefreshIndicator(
         onRefresh: _loadUser,
         child: _loading

--- a/mobile/lib/src/shared/main_app_bar.dart
+++ b/mobile/lib/src/shared/main_app_bar.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:go_router/go_router.dart';
+import '../services/http_client.dart';
+
+class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  const MainAppBar({super.key, required this.title});
+
+  Future<void> _logout(BuildContext context) async {
+    await HttpClient.instance.clearCookies();
+    if (context.mounted) context.go('/');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      titleSpacing: 0,
+      title: Row(
+        children: [
+          SvgPicture.asset('assets/logo.svg', height: 32),
+          const SizedBox(width: 8),
+          Text(title),
+        ],
+      ),
+      actions: [
+        IconButton(
+          onPressed: () => _logout(context),
+          icon: const Icon(Icons.logout),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   dio_cookie_manager: ^3.2.0
   go_router: ^15.1.1
   geolocator: ^14.0.1
+  flutter_svg: ^2.0.9
 
 dev_dependencies:
   flutter_test:
@@ -61,6 +62,8 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+  assets:
+    - assets/logo.svg
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- add reusable `MainAppBar` widget displaying SVG logo, title, and logout button
- create placeholder `HomeScreen` and `ChatScreen`
- apply `MainAppBar` to Home, Map, Chat and Profile screens
- expose new screens in navigation
- include logo asset and update dependencies

## Testing
- `flutter` is not installed so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_684784ef4420832394a9669c8149bb5f