### PR TITLE
Add cookie-based routing

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'src/app.dart';
+import 'src/services/http_client.dart';
 
 void main() {
-  runApp(App());
+  final hasCookie = HttpClient.instance.hasAuthCookie();
+  runApp(App(initialLocation: hasCookie ? '/home' : '/'));
 }

--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -11,10 +11,12 @@ import 'features/dog/presentation/dog_profile_screen.dart';
 import 'styles/app_theme.dart';
 
 class App extends StatelessWidget {
-  App({super.key});
+  App({super.key, required this.initialLocation});
 
-  final GoRouter _router = GoRouter(
-    initialLocation: '/',
+  final String initialLocation;
+
+  late final GoRouter _router = GoRouter(
+    initialLocation: initialLocation,
     routes: [
       GoRoute(
         path: '/',

--- a/mobile/lib/src/env.dart
+++ b/mobile/lib/src/env.dart
@@ -2,3 +2,5 @@ const String apiBaseUrl = String.fromEnvironment(
   'API_BASE_URL',
   defaultValue: 'http://10.0.2.2:8080',
 );
+
+const String jwtCookieName = 'pawconnect-jwt';

--- a/mobile/lib/src/services/http_client.dart
+++ b/mobile/lib/src/services/http_client.dart
@@ -18,6 +18,12 @@ class HttpClient {
 
   Dio get dio => _dio;
 
+  bool hasAuthCookie() {
+    final cookies =
+        _cookieJar.loadForRequest(Uri.parse('$apiBaseUrl/api'));
+    return cookies.any((cookie) => cookie.name == jwtCookieName);
+  }
+
   Future<void> clearCookies() async {
     await _cookieJar.deleteAll();
   }


### PR DESCRIPTION
## Summary
- define JWT cookie name in `env.dart`
- support checking auth cookie in `HttpClient`
- allow starting `App` at custom initial route
- decide initial route in `main` by inspecting auth cookie

## Testing
- `dart format mobile/lib/src/env.dart mobile/lib/src/services/http_client.dart mobile/lib/src/app.dart mobile/lib/main.dart mobile/lib/src/shared/main_app_bar.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68478c6ea038832390daa9400151e3b6