### PR TITLE
Enable persistent cookies in Flutter app

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -3,6 +3,8 @@ import 'src/app.dart';
 import 'src/services/http_client.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await HttpClient.instance.init();
   final hasCookie = await HttpClient.instance.hasAuthCookie();
   runApp(App(initialLocation: hasCookie ? '/home' : '/'));
 }

--- a/mobile/lib/src/services/http_client.dart
+++ b/mobile/lib/src/services/http_client.dart
@@ -1,22 +1,29 @@
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dio/dio.dart';
 import 'package:dio_cookie_manager/dio_cookie_manager.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 
 import '../env.dart';
 
 class HttpClient {
   HttpClient._() {
     _dio = Dio(BaseOptions(baseUrl: '$apiBaseUrl/api'));
-    _cookieJar = CookieJar();
-    _dio.interceptors.add(CookieManager(_cookieJar));
   }
 
   static final HttpClient instance = HttpClient._();
 
   late final Dio _dio;
-  late final CookieJar _cookieJar;
+  late PersistCookieJar _cookieJar;
 
   Dio get dio => _dio;
+
+  Future<void> init() async {
+    final dir = await getApplicationSupportDirectory();
+    _cookieJar =
+        PersistCookieJar(storage: FileStorage(p.join(dir.path, 'cookies')));
+    _dio.interceptors.add(CookieManager(_cookieJar));
+  }
 
 Future<bool> hasAuthCookie() async {
   final cookies =

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   dio: ^5.8.0+1
   cookie_jar: ^4.0.8
   dio_cookie_manager: ^3.2.0
+  path_provider: ^2.1.1
+  path: ^1.8.3
   go_router: ^15.1.1
   geolocator: ^14.0.1
   flutter_svg: ^2.0.9


### PR DESCRIPTION
## Summary
- store cookies on disk using `PersistCookieJar`
- initialize persistent cookie storage at app startup
- add `path_provider` and `path` packages

## Testing
- `flutter pub get` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479080943883239cb346fbddbed84c