### PR TITLE
Add candidate user and dog response models

### DIFF
--- a/mobile/lib/src/models/candidate_user.dart
+++ b/mobile/lib/src/models/candidate_user.dart
@@ -1,0 +1,26 @@
+import 'dog_response.dart';
+
+class CandidateUser {
+  final int id;
+  final String username;
+  final String? bio;
+  final String? gender;
+  final String? profilePhotoUrl;
+  final double distanceKm;
+  final List<String> languages;
+  final List<DogResponse> dogs;
+  final int score;
+
+  CandidateUser.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        username = json['username'],
+        bio = json['bio'],
+        gender = json['gender'],
+        profilePhotoUrl = json['profilePhotoUrl'],
+        distanceKm = (json['distanceKm'] as num).toDouble(),
+        languages = List<String>.from(json['languages'] ?? []),
+        dogs = (json['dogs'] as List<dynamic>? ?? [])
+            .map((e) => DogResponse.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        score = json['score'];
+}

--- a/mobile/lib/src/models/dog_response.dart
+++ b/mobile/lib/src/models/dog_response.dart
@@ -1,0 +1,26 @@
+class DogResponse {
+  final int id;
+  final String name;
+  final String? breed;
+  final String? birthdate;
+  final String? size;
+  final String? gender;
+  final String? personality;
+  final String? activityLevel;
+  final String? about;
+  final List<String> photoUrls;
+  final int ownerId;
+
+  DogResponse.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        name = json['name'],
+        breed = json['breed'],
+        birthdate = json['birthdate'],
+        size = json['size'],
+        gender = json['gender'],
+        personality = json['personality'],
+        activityLevel = json['activityLevel'],
+        about = json['about'],
+        photoUrls = List<String>.from(json['photoUrls'] ?? []),
+        ownerId = json['ownerId'];
+}


### PR DESCRIPTION
## Summary
- add `CandidateUser` model for matching user candidates
- add `DogResponse` model used by candidate users

## Testing
- `dart` tests not run (none present)

------
https://chatgpt.com/codex/tasks/task_e_6847959defec83239e9c7aaac9c14817