### PR TITLE
Add match service

### DIFF
--- a/mobile/lib/src/services/match_service.dart
+++ b/mobile/lib/src/services/match_service.dart
@@ -1,0 +1,33 @@
+import 'package:dio/dio.dart';
+
+import 'http_client.dart';
+
+class MatchService {
+  MatchService._();
+
+  static final MatchService instance = MatchService._();
+  final Dio _dio = HttpClient.instance.dio;
+
+  Future<Response<dynamic>> getCandidates({int limit = 20, double radiusKm = 25}) {
+    return _dio.get(
+      '/matches/candidates',
+      queryParameters: {
+        'limit': limit,
+        'radiusKm': radiusKm,
+      },
+    );
+  }
+
+  Future<Response<dynamic>> createSwipe({
+    required int targetUserId,
+    required String decision,
+  }) {
+    return _dio.post(
+      '/matches/swipes',
+      data: {
+        'targetUserId': targetUserId,
+        'decision': decision,
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `MatchService` for candidate retrieval and swiping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847969f925c8323868c5fd986da41d5