### PR TITLE
Add chat list screen

### DIFF
--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -4,6 +4,7 @@ import 'features/auth/presentation/login_screen.dart';
 import 'features/auth/presentation/signup_screen.dart';
 import 'features/map/presentation/map_screen.dart';
 import 'features/home/presentation/home_screen.dart';
+import 'features/chat/presentation/chat_list_screen.dart';
 import 'features/chat/presentation/chat_screen.dart';
 import 'features/profile/profile_completion_screen.dart';
 import 'features/profile/presentation/profile_screen.dart';
@@ -46,6 +47,13 @@ class App extends StatelessWidget {
           return DogProfileScreen(dogId: id);
         },
       ),
+      GoRoute(
+        path: '/chats/:id',
+        builder: (context, state) {
+          final id = int.parse(state.pathParameters['id']!);
+          return ChatScreen(chatId: id);
+        },
+      ),
     ],
   );
 
@@ -71,7 +79,7 @@ class _MyHomePageState extends State<MyHomePage> {
   static final List<Widget> _pages = <Widget>[
     const HomeScreen(),
     const MapScreen(),
-    const ChatScreen(),
+    const ChatListScreen(),
     const ProfileScreen(),
   ];
 

--- a/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../models/chat_response.dart';
+import '../../../services/chat_service.dart';
+import '../../../shared/main_app_bar.dart';
+
+class ChatListScreen extends StatefulWidget {
+  const ChatListScreen({super.key});
+
+  @override
+  State<ChatListScreen> createState() => _ChatListScreenState();
+}
+
+class _ChatListScreenState extends State<ChatListScreen> {
+  final List<ChatResponse> _chats = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadChats();
+  }
+
+  Future<void> _loadChats() async {
+    setState(() => _loading = true);
+    try {
+      final res = await ChatService.instance.getChats();
+      _chats
+        ..clear()
+        ..addAll((res.data as List<dynamic>)
+            .map((e) => ChatResponse.fromJson(e as Map<String, dynamic>)));
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget body;
+    if (_loading) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (_chats.isEmpty) {
+      body = const Center(child: Text('No chats found'));
+    } else {
+      body = ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: _chats.length,
+        itemBuilder: (context, index) {
+          final chat = _chats[index];
+          return ListTile(
+            title: Text('Chat ${chat.id}'),
+            onTap: () => context.push('/chats/${chat.id}'),
+          );
+        },
+      );
+    }
+
+    return Scaffold(
+      appBar: const MainAppBar(),
+      body: RefreshIndicator(onRefresh: _loadChats, child: body),
+    );
+  }
+}

--- a/mobile/lib/src/features/chat/presentation/chat_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_screen.dart
@@ -2,13 +2,15 @@ import 'package:flutter/material.dart';
 import '../../../shared/main_app_bar.dart';
 
 class ChatScreen extends StatelessWidget {
-  const ChatScreen({super.key});
+  final int chatId;
+
+  const ChatScreen({super.key, required this.chatId});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: MainAppBar(),
-      body: Center(child: Text('Chat page placeholder')),
+    return Scaffold(
+      appBar: const MainAppBar(),
+      body: Center(child: Text('Chat $chatId placeholder')),
     );
   }
 }

--- a/mobile/lib/src/models/chat_response.dart
+++ b/mobile/lib/src/models/chat_response.dart
@@ -1,0 +1,14 @@
+import 'dart:core';
+
+class ChatResponse {
+  final int id;
+  final String type;
+  final int? eventId;
+  final List<int> participantIds;
+
+  ChatResponse.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        type = json['type'],
+        eventId = json['eventId'],
+        participantIds = List<int>.from(json['participantIds'] ?? []);
+}

--- a/mobile/lib/src/services/chat_service.dart
+++ b/mobile/lib/src/services/chat_service.dart
@@ -1,0 +1,20 @@
+import 'package:dio/dio.dart';
+
+import 'http_client.dart';
+
+class ChatService {
+  ChatService._();
+
+  static final ChatService instance = ChatService._();
+  final Dio _dio = HttpClient.instance.dio;
+
+  Future<Response<dynamic>> getChats() {
+    return _dio.get('/chats');
+  }
+
+  Future<Response<dynamic>> getMessages(int chatId,
+      {int page = 0, int limit = 20}) {
+    return _dio.get('/chats/$chatId/messages',
+        queryParameters: {'page': page, 'limit': limit});
+  }
+}


### PR DESCRIPTION
## Summary
- implement ChatService and ChatResponse model
- add ChatListScreen with pull-to-refresh
- make ChatScreen accept a chat ID
- wire up new routes and bottom nav

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e19861648323a9c520da344e400c