### PR TITLE
Add lastReadMessage column

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/chat/model/ChatParticipant.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/model/ChatParticipant.java
@@ -1,6 +1,7 @@
 package com.pawconnect.backend.chat.model;
 
 import com.pawconnect.backend.user.model.User;
+import com.pawconnect.backend.chat.model.Message;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,4 +23,8 @@ public class ChatParticipant {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "last_read_message_id")
+    private Message lastReadMessage;
 }

--- a/backend/src/main/java/com/pawconnect/backend/chat/repository/ChatParticipantRepository.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/repository/ChatParticipantRepository.java
@@ -9,4 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, ChatParticipantId> {
     boolean existsByChatIdAndUserId(Long chatId, Long userId);
     void deleteByChatIdAndUserId(Long chatId, Long userId);
+    java.util.Optional<ChatParticipant> findByChatIdAndUserId(Long chatId, Long userId);
 }

--- a/backend/src/main/resources/db/migration/V4__add_last_read_message_to_chat_participants.sql
+++ b/backend/src/main/resources/db/migration/V4__add_last_read_message_to_chat_participants.sql
@@ -1,0 +1,7 @@
+ALTER TABLE chat_participants
+    ADD COLUMN last_read_message_id BIGINT;
+
+ALTER TABLE chat_participants
+    ADD CONSTRAINT fk_chat_participants_last_read_message
+        FOREIGN KEY (last_read_message_id)
+            REFERENCES messages(id);


### PR DESCRIPTION
## Summary
- track read progress with `lastReadMessage` in `ChatParticipant`
- look up participants by chat and user IDs
- provide migration for the new column

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_6849ed32de048323aa6698d62d337946