### PR TITLE
Add chat message repository helpers

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/chat/repository/MessageRepository.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/repository/MessageRepository.java
@@ -9,4 +9,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MessageRepository extends JpaRepository<Message, Long> {
     Page<Message> findByChatIdOrderByTimestampDesc(Long chatId, Pageable pageable);
+
+    Message findFirstByChatIdOrderByTimestampDesc(Long chatId);
+
+    int countByChatIdAndIdGreaterThan(Long chatId, Long id);
 }


### PR DESCRIPTION
## Summary
- add `findFirstByChatIdOrderByTimestampDesc` for quick access to the newest message
- add `countByChatIdAndIdGreaterThan` for unread message counts

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_6849ed6f17488323bef142577da00258