### PR TITLE
Add last message metadata to ChatResponse

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatMapper.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatMapper.java
@@ -7,6 +7,10 @@ import org.mapstruct.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Mapper for converting chat entities to DTOs.
+ */
+
 @Mapper(componentModel = "spring")
 public interface ChatMapper {
     Chat toEntity(ChatCreateRequest request);
@@ -14,6 +18,16 @@ public interface ChatMapper {
     @Mapping(source = "event.id", target = "eventId")
     @Mapping(target = "participantIds", expression = "java(mapParticipants(chat.getParticipants()))")
     ChatResponse toDto(Chat chat);
+
+    /**
+     * Convenience method allowing manual setting of the last message and unread count.
+     */
+    default ChatResponse toDto(Chat chat, ChatMessageResponse lastMessage, int unreadCount) {
+        ChatResponse dto = toDto(chat);
+        dto.setLastMessage(lastMessage);
+        dto.setUnreadCount(unreadCount);
+        return dto;
+    }
 
     default List<Long> mapParticipants(List<ChatParticipant> participants) {
         if (participants == null) return List.of();

--- a/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatResponse.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatResponse.java
@@ -11,4 +11,10 @@ public class ChatResponse {
     private ChatType type;
     private Long eventId;
     private List<Long> participantIds;
+
+    /** Most recent message in the chat. */
+    private ChatMessageResponse lastMessage;
+
+    /** Number of unread messages for the requesting user. */
+    private int unreadCount;
 }

--- a/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
@@ -3,10 +3,13 @@ package com.pawconnect.backend.chat.service;
 import com.pawconnect.backend.chat.dto.ChatCreateRequest;
 import com.pawconnect.backend.chat.dto.ChatMapper;
 import com.pawconnect.backend.chat.dto.ChatResponse;
+import com.pawconnect.backend.chat.dto.ChatMessageResponse;
 import com.pawconnect.backend.chat.model.Chat;
 import com.pawconnect.backend.chat.model.ChatParticipant;
+import com.pawconnect.backend.chat.model.Message;
 import com.pawconnect.backend.chat.repository.ChatRepository;
 import com.pawconnect.backend.chat.repository.ChatParticipantRepository;
+import com.pawconnect.backend.chat.repository.MessageRepository;
 import com.pawconnect.backend.common.exception.NotFoundException;
 import com.pawconnect.backend.common.exception.UnauthorizedAccessException;
 import com.pawconnect.backend.common.enums.ChatType;
@@ -28,6 +31,7 @@ public class ChatService {
     private final ChatMapper chatMapper;
     private final UserService userService;
     private final ChatParticipantRepository chatParticipantRepository;
+    private final MessageRepository messageRepository;
 
     public ChatResponse createChat(ChatCreateRequest request) {
         Chat chat = chatMapper.toEntity(request);
@@ -103,7 +107,29 @@ public class ChatService {
     public List<ChatResponse> getChatsByUserId(Long userId) {
         return chatRepository.findByParticipantsUserId(userId)
                 .stream()
-                .map(chatMapper::toDto)
+                .map(chat -> {
+                    // Retrieve latest message
+                    Message last = messageRepository.findFirstByChatIdOrderByTimestampDesc(chat.getId());
+                    ChatMessageResponse lastDto = null;
+                    if (last != null) {
+                        lastDto = new ChatMessageResponse();
+                        lastDto.setId(last.getId());
+                        lastDto.setChatId(chat.getId());
+                        lastDto.setSenderId(last.getSender().getId());
+                        lastDto.setContent(last.getContent());
+                        lastDto.setTimestamp(last.getTimestamp());
+                    }
+
+                    // Determine unread message count for the user
+                    java.util.Optional<ChatParticipant> participantOpt =
+                            chatParticipantRepository.findByChatIdAndUserId(chat.getId(), userId);
+                    long lastReadId = participantOpt.flatMap(p ->
+                                    java.util.Optional.ofNullable(p.getLastReadMessage()).map(Message::getId))
+                            .orElse(0L);
+                    int unread = messageRepository.countByChatIdAndIdGreaterThan(chat.getId(), lastReadId);
+
+                    return chatMapper.toDto(chat, lastDto, unread);
+                })
                 .toList();
     }
 


### PR DESCRIPTION
## Summary
- include last message info and unread count in `ChatResponse`
- extend `ChatMapper` with helper method for these fields
- populate new fields in `ChatService`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ef61f69c8323bae6e86e56141abe