### PR TITLE
Add last message info to chat list

### DIFF
--- a/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
@@ -74,7 +74,7 @@ class _ChatListScreenState extends State<ChatListScreen> {
                         ),
                         const SizedBox(height: 4),
                         Text(
-                          'Last message preview...',
+                          chat.lastMessage?.content ?? 'No messages yet',
                           style: Theme.of(context).textTheme.bodySmall,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
@@ -91,26 +91,27 @@ class _ChatListScreenState extends State<ChatListScreen> {
                         style: Theme.of(context).textTheme.bodySmall,
                       ),
                       const SizedBox(height: 4),
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 6,
-                          vertical: 2,
+                      if (chat.unreadCount > 0)
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 6,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.primary,
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            '${chat.unreadCount}',
+                            style: Theme.of(context)
+                                .textTheme
+                                .labelSmall
+                                ?.copyWith(
+                                  color:
+                                      Theme.of(context).colorScheme.onPrimary,
+                                ),
+                          ),
                         ),
-                        decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.primary,
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: Text(
-                          '1',
-                          style: Theme.of(context)
-                              .textTheme
-                              .labelSmall
-                              ?.copyWith(
-                                color:
-                                    Theme.of(context).colorScheme.onPrimary,
-                              ),
-                        ),
-                      ),
                     ],
                   ),
                 ],

--- a/mobile/lib/src/models/chat_message_response.dart
+++ b/mobile/lib/src/models/chat_message_response.dart
@@ -1,0 +1,14 @@
+class ChatMessageResponse {
+  final int id;
+  final int chatId;
+  final int senderId;
+  final String content;
+  final String timestamp;
+
+  ChatMessageResponse.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        chatId = json['chatId'],
+        senderId = json['senderId'],
+        content = json['content'],
+        timestamp = json['timestamp'];
+}

--- a/mobile/lib/src/models/chat_response.dart
+++ b/mobile/lib/src/models/chat_response.dart
@@ -1,14 +1,23 @@
 import 'dart:core';
 
+import 'chat_message_response.dart';
+
 class ChatResponse {
   final int id;
   final String type;
   final int? eventId;
   final List<int> participantIds;
+  final ChatMessageResponse? lastMessage;
+  final int unreadCount;
 
   ChatResponse.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         type = json['type'],
         eventId = json['eventId'],
-        participantIds = List<int>.from(json['participantIds'] ?? []);
+        participantIds = List<int>.from(json['participantIds'] ?? []),
+        lastMessage = json['lastMessage'] != null
+            ? ChatMessageResponse.fromJson(
+                json['lastMessage'] as Map<String, dynamic>)
+            : null,
+        unreadCount = json['unreadCount'] ?? 0;
 }


### PR DESCRIPTION
## Summary
- include lastMessage and unreadCount in ChatResponse model
- display last message and unread badge on chat list

## Testing
- `dart format mobile/lib/src/models/chat_message_response.dart mobile/lib/src/models/chat_response.dart mobile/lib/src/features/chat/presentation/chat_list_screen.dart` *(fails: dart command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f913221c832394e12085e5b892aa