### PR TITLE
Update seeding for last read messages

### DIFF
--- a/backend/src/main/resources/db/migration/V5__seed_last_read_message_ids.sql
+++ b/backend/src/main/resources/db/migration/V5__seed_last_read_message_ids.sql
@@ -1,0 +1,11 @@
+-- V5__seed_last_read_message_ids.sql
+-- Populate last_read_message_id for existing chat participants after column addition.
+
+UPDATE chat_participants cp
+SET last_read_message_id = sub.last_id
+FROM (
+    SELECT chat_id, MAX(id) AS last_id
+    FROM messages
+    GROUP BY chat_id
+) sub
+WHERE cp.chat_id = sub.chat_id;


### PR DESCRIPTION
## Summary
- seed last_read_message_id for existing chat participants

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven)*

------
https://chatgpt.com/codex/tasks/task_e_6849ec5732cc8323b3b118fad7d2f77b