### PR TITLE
Implement chat titles

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatMapper.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatMapper.java
@@ -17,6 +17,7 @@ public interface ChatMapper {
 
     @Mapping(source = "event.id", target = "eventId")
     @Mapping(target = "participantIds", expression = "java(mapParticipants(chat.getParticipants()))")
+    @Mapping(target = "title", ignore = true)
     ChatResponse toDto(Chat chat);
 
     /**

--- a/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatResponse.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/dto/ChatResponse.java
@@ -9,6 +9,8 @@ import java.util.List;
 public class ChatResponse {
     private Long id;
     private ChatType type;
+    /** Human-readable chat title. */
+    private String title;
     private Long eventId;
     private List<Long> participantIds;
 

--- a/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
@@ -132,7 +132,20 @@ public class ChatService {
                 .orElse(0L);
         int unread = messageRepository.countByChatIdAndIdGreaterThan(chat.getId(), lastReadId);
 
-        return chatMapper.toDto(chat, lastDto, unread);
+        ChatResponse dto = chatMapper.toDto(chat, lastDto, unread);
+
+        String title;
+        if (chat.getType() == ChatType.GROUP) {
+            title = chat.getEvent() != null ? chat.getEvent().getTitle() : "Group Chat";
+        } else {
+            title = chat.getParticipants().stream()
+                    .filter(p -> !p.getUser().getId().equals(userId))
+                    .map(p -> p.getUser().getUsername())
+                    .findFirst()
+                    .orElse("Private Chat");
+        }
+        dto.setTitle(title);
+        return dto;
     }
 
     public Chat getChatByEventId(Long eventId) {

--- a/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
@@ -66,7 +66,7 @@ class _ChatListScreenState extends State<ChatListScreen> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          'Chat ${chat.id}',
+                          chat.title,
                           style: Theme.of(context)
                               .textTheme
                               .titleMedium

--- a/mobile/lib/src/models/chat_response.dart
+++ b/mobile/lib/src/models/chat_response.dart
@@ -5,6 +5,7 @@ import 'chat_message_response.dart';
 class ChatResponse {
   final int id;
   final String type;
+  final String title;
   final int? eventId;
   final List<int> participantIds;
   final ChatMessageResponse? lastMessage;
@@ -13,6 +14,7 @@ class ChatResponse {
   ChatResponse.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         type = json['type'],
+        title = json['title'] ?? 'Chat ${json['id']}',
         eventId = json['eventId'],
         participantIds = List<int>.from(json['participantIds'] ?? []),
         lastMessage = json['lastMessage'] != null


### PR DESCRIPTION
## Summary
- add `title` property to chat responses on backend and mobile
- compute titles in `ChatService`
- ignore mapping of title field in `ChatMapper`
- show chat titles in the chat list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849fe32f95c832397886ed72c0ad779