### PR TITLE
Add public profile and event screens

### DIFF
--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -8,6 +8,8 @@ import 'features/chat/presentation/chat_list_screen.dart';
 import 'features/chat/presentation/chat_screen.dart';
 import 'features/profile/profile_completion_screen.dart';
 import 'features/profile/presentation/profile_screen.dart';
+import 'features/profile/presentation/public_profile_screen.dart';
+import 'features/event/presentation/event_screen.dart';
 import 'features/dog/presentation/dog_profile_screen.dart';
 import 'styles/app_theme.dart';
 
@@ -45,6 +47,22 @@ class App extends StatelessWidget {
         builder: (context, state) {
           final id = int.parse(state.pathParameters['id']!);
           return DogProfileScreen(dogId: id);
+        },
+      ),
+      GoRoute(
+        path: '/public/:username',
+        name: 'public-profile',
+        builder: (context, state) {
+          final username = state.pathParameters['username']!;
+          return PublicProfileScreen(username: username);
+        },
+      ),
+      GoRoute(
+        path: '/events/:id',
+        name: 'event',
+        builder: (context, state) {
+          final id = int.parse(state.pathParameters['id']!);
+          return EventScreen(eventId: id);
         },
       ),
       GoRoute(

--- a/mobile/lib/src/features/chat/widgets/chat_app_bar.dart
+++ b/mobile/lib/src/features/chat/widgets/chat_app_bar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../models/chat_response.dart';
 
@@ -8,25 +9,11 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   void _openPlaceholder(BuildContext context) {
     if (chat.type.toUpperCase() == 'GROUP') {
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (_) => const Scaffold(
-            appBar: AppBar(title: Text('Event')),
-            body: Center(child: Text('Event screen placeholder')),
-          ),
-        ),
-      );
+      if (chat.eventId != null) {
+        context.push('/events/${chat.eventId}');
+      }
     } else {
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (_) => const Scaffold(
-            appBar: AppBar(title: Text('Public Profile')),
-            body: Center(child: Text('Public profile placeholder')),
-          ),
-        ),
-      );
+      context.push('/public/${chat.title}');
     }
   }
 

--- a/mobile/lib/src/features/event/presentation/event_screen.dart
+++ b/mobile/lib/src/features/event/presentation/event_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class EventScreen extends StatelessWidget {
+  final int eventId;
+
+  const EventScreen({super.key, required this.eventId});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Event')),
+      body: Center(
+        child: Text('Event ID: $eventId'),
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/features/profile/presentation/public_profile_screen.dart
+++ b/mobile/lib/src/features/profile/presentation/public_profile_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class PublicProfileScreen extends StatelessWidget {
+  final String username;
+
+  const PublicProfileScreen({super.key, required this.username});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Public Profile')),
+      body: Center(
+        child: Text('Username: $username'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show a simple PublicProfileScreen and EventScreen
- register new routes in the GoRouter
- make ChatAppBar open these routes when tapping on chat titles

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a491bec3083238146a2be54429b0e