### PR TITLE
Add message state handling

### DIFF
--- a/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
@@ -3,7 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 
 import '../../../models/chat_response.dart';
-import '../../../models/chat_message_response.dart';
+import '../../../models/chat_message.dart';
 import '../../../services/chat_service.dart';
 import '../../../services/chat_socket_service.dart';
 import '../../../shared/main_app_bar.dart';
@@ -46,7 +46,7 @@ class _ChatListScreenState extends State<ChatListScreen> {
     }
   }
 
-  String _formatTimestamp(ChatMessageResponse? message) {
+  String _formatTimestamp(dynamic message) {
     if (message == null) return '';
     try {
       final date = DateTime.parse(message.timestamp).toLocal();

--- a/mobile/lib/src/features/chat/widgets/message_bubbles.dart
+++ b/mobile/lib/src/features/chat/widgets/message_bubbles.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-import '../../../models/chat_message_response.dart';
+import '../../../models/chat_message.dart';
+import '../../../services/chat_socket_service.dart';
 
 class MessageBubble extends StatelessWidget {
-  final ChatMessageResponse message;
+  final ChatMessage message;
   final bool isMe;
   const MessageBubble({super.key, required this.message, required this.isMe});
 
@@ -48,7 +49,37 @@ class MessageBubble extends StatelessWidget {
                           ?.copyWith(color: textColor)),
                   if (isMe) ...[
                     const SizedBox(width: 4),
-                    Icon(Icons.check, size: 12, color: textColor),
+                    if (message.status == ChatMessageStatus.sending)
+                      SizedBox(
+                        width: 12,
+                        height: 12,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(textColor),
+                        ),
+                      )
+                    else if (message.status == ChatMessageStatus.sent)
+                      Icon(Icons.check, size: 12, color: textColor)
+                    else
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            Icons.error,
+                            size: 12,
+                            color: Theme.of(context).colorScheme.error,
+                          ),
+                          GestureDetector(
+                            onTap: () => ChatSocketService.instance
+                                .sendMessage(message.chatId, message.content),
+                            child: Icon(
+                              Icons.refresh,
+                              size: 12,
+                              color: Theme.of(context).colorScheme.error,
+                            ),
+                          ),
+                        ],
+                      ),
                   ]
                 ],
               )

--- a/mobile/lib/src/models/chat_message.dart
+++ b/mobile/lib/src/models/chat_message.dart
@@ -1,0 +1,40 @@
+enum ChatMessageStatus { sending, sent, error }
+
+class ChatMessage {
+  final int? id;
+  final int chatId;
+  final int senderId;
+  final String content;
+  final String timestamp;
+  ChatMessageStatus status;
+
+  ChatMessage({
+    this.id,
+    required this.chatId,
+    required this.senderId,
+    required this.content,
+    required this.timestamp,
+    this.status = ChatMessageStatus.sent,
+  });
+
+  factory ChatMessage.fromJson(Map<String, dynamic> json) {
+    return ChatMessage(
+      id: json['id'],
+      chatId: json['chatId'],
+      senderId: json['senderId'],
+      content: json['content'],
+      timestamp: json['timestamp'],
+      status: ChatMessageStatus.sent,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'chatId': chatId,
+      'senderId': senderId,
+      'content': content,
+      'timestamp': timestamp,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- track message status with a new `ChatMessage` model
- handle pending messages and state changes in `ChatSocketService`
- show send progress and errors in chat bubbles
- wire up chat screens to the new model

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a4ad043b48323b80bd35cdb4c139a