### PR TITLE
Implement chat notification navigation

### DIFF
--- a/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
@@ -22,7 +22,7 @@ class _ChatListScreenState extends State<ChatListScreen> {
   @override
   void initState() {
     super.initState();
-    ChatSocketService.instance.initNotifications();
+    ChatSocketService.instance.initNotifications(context);
     ChatSocketService.instance.connect();
     _loadChats();
     ChatSocketService.instance.messages.listen((msg) {
@@ -38,6 +38,7 @@ class _ChatListScreenState extends State<ChatListScreen> {
         ..clear()
         ..addAll((res.data as List<dynamic>)
             .map((e) => ChatResponse.fromJson(e as Map<String, dynamic>)));
+      ChatSocketService.instance.updateChatTitles(_chats);
       for (final chat in _chats) {
         ChatSocketService.instance.subscribe(chat.id);
       }

--- a/mobile/lib/src/features/chat/presentation/chat_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_screen.dart
@@ -58,6 +58,7 @@ class _ChatScreenState extends State<ChatScreen> {
         'unreadCount': 0,
       }),
     );
+    ChatSocketService.instance.updateChatTitle(widget.chatId, _chat!.title);
     final userRes = await UserService.instance.getCurrentUser();
     _userId = CurrentUserResponse.fromJson(userRes.data).id;
     ChatSocketService.instance.setCurrentUserId(_userId!);


### PR DESCRIPTION
## Summary
- display chat title in push notifications
- add payload with chat ID to notifications
- navigate to the chat when a notification is tapped

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4c4da704832390af08ff8cac0120