### PR TITLE
Add toJson for ChatMessageResponse

### DIFF
--- a/mobile/lib/src/models/chat_message_response.dart
+++ b/mobile/lib/src/models/chat_message_response.dart
@@ -11,4 +11,14 @@ class ChatMessageResponse {
         senderId = json['senderId'],
         content = json['content'],
         timestamp = json['timestamp'];
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'chatId': chatId,
+      'senderId': senderId,
+      'content': content,
+      'timestamp': timestamp,
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- implement `toJson` in `chat_message_response.dart` so `ChatMessageResponse` can be serialized

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a517afcb4832382ec1b138a4286d3