### PR TITLE
Fix latest message variable type in chat list

### DIFF
--- a/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
@@ -80,7 +80,8 @@ class _ChatListScreenState extends State<ChatListScreen> {
         padding: const EdgeInsets.symmetric(vertical: 8),
         itemBuilder: (context, index) {
           final chat = _chats[index];
-          final latest = ChatSocketService.instance.latestMessages[chat.id] ??
+          final dynamic latest = ChatSocketService.instance
+                  .latestMessages[chat.id] ??
               chat.lastMessage;
           return InkWell(
             onTap: () => context.push('/chats/${chat.id}'),


### PR DESCRIPTION
## Summary
- ensure the latest message can be accessed safely by casting to `dynamic`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a5277f0908323b2b51c3a23fdd58c