### PR TITLE
Implement websocket auto connect and reconnect overlay

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,10 +1,27 @@
 import 'package:flutter/material.dart';
 import 'src/app.dart';
 import 'src/services/http_client.dart';
+import 'src/services/chat_service.dart';
+import 'src/services/chat_socket_service.dart';
+import 'src/models/chat_response.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await HttpClient.instance.init();
   final hasCookie = await HttpClient.instance.hasAuthCookie();
+  if (hasCookie) {
+    await ChatSocketService.instance.connect();
+    try {
+      final res = await ChatService.instance.getChats();
+      final chats = (res.data as List<dynamic>)
+          .map((e) => ChatResponse.fromJson(e as Map<String, dynamic>));
+      ChatSocketService.instance.updateChatTitles(chats);
+      for (final chat in chats) {
+        ChatSocketService.instance.subscribe(chat.id);
+      }
+    } catch (_) {
+      // ignore errors during startup
+    }
+  }
   runApp(App(initialLocation: hasCookie ? '/home' : '/'));
 }

--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -12,6 +12,7 @@ import 'features/profile/presentation/public_profile_screen.dart';
 import 'features/event/presentation/event_screen.dart';
 import 'features/dog/presentation/dog_profile_screen.dart';
 import 'styles/app_theme.dart';
+import 'shared/connection_status_bubble.dart';
 
 class App extends StatelessWidget {
   App({super.key, required this.initialLocation});
@@ -80,6 +81,12 @@ class App extends StatelessWidget {
     return MaterialApp.router(
       theme: AppTheme.light,
       routerConfig: _router,
+      builder: (context, child) => Stack(
+        children: [
+          if (child != null) child,
+          const ConnectionStatusBubble(),
+        ],
+      ),
     );
   }
 }

--- a/mobile/lib/src/shared/connection_status_bubble.dart
+++ b/mobile/lib/src/shared/connection_status_bubble.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import '../services/chat_socket_service.dart';
+
+class ConnectionStatusBubble extends StatelessWidget {
+  const ConnectionStatusBubble({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<String?>(
+      valueListenable: ChatSocketService.instance.statusNotifier,
+      builder: (context, value, _) {
+        if (value == null) return const SizedBox.shrink();
+        return Positioned(
+          left: 16,
+          bottom: 16,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Text(
+              value,
+              style: Theme.of(context).textTheme.labelSmall,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- connect to chat on app start and subscribe to all chats
- add reconnect and connecting handling in `ChatSocketService`
- show connection status bubble in the bottom corner
- overlay connection status globally

## Testing
- `dart` and `flutter` commands were unavailable so formatting or tests were not executed

------
https://chatgpt.com/codex/tasks/task_e_684a50ac2cd4832394c9a8b642c486f7