### PR TITLE
Improve ChatSocketService reliability

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -7,6 +7,7 @@ import 'src/models/chat_response.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await ChatSocketService.instance.init();
   await HttpClient.instance.init();
   final hasCookie = await HttpClient.instance.hasAuthCookie();
   if (hasCookie) {

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   path: ^1.8.3
   go_router: ^15.1.1
   geolocator: ^14.0.1
+  connectivity_plus: ^5.0.2
   flutter_svg: ^2.0.9
   flutter_card_swiper: ^7.0.0
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- monitor connectivity and automatically reconnect
- use `reconnectDelay` and heartbeats instead of manual timers
- log WebSocket and STOMP errors
- expose `init` and `dispose` helpers
- add `connectivity_plus` dependency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ba17c99ac8323bf8a58af6889faf6