### PR TITLE
Add swipeable candidate card

### DIFF
--- a/mobile/lib/src/features/home/presentation/home_screen.dart
+++ b/mobile/lib/src/features/home/presentation/home_screen.dart
@@ -70,7 +70,10 @@ class _HomeScreenState extends State<HomeScreen> {
             return true;
           },
           cardBuilder: (context, index, horizontalOffset, verticalOffset) {
-            return CandidateCard(candidate: _candidates[index]);
+            return CandidateCard(
+              candidate: _candidates[index],
+              cardController: _cardController,
+            );
           },
         ),
       );


### PR DESCRIPTION
## Summary
- redesign CandidateCard with a PageView that shows user and dog photos
- add dot indicators, gradient info overlay and a profile info button
- add action buttons for swipe/undo and connect to `CardSwiperController`
- pass the swiper controller from `HomeScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7e1a7af083239fedb94df91161de