### PR TITLE
Add cached network image for remote pics

### DIFF
--- a/mobile/lib/src/features/home/presentation/candidate_card.dart
+++ b/mobile/lib/src/features/home/presentation/candidate_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_card_swiper/flutter_card_swiper.dart';
 import 'package:go_router/go_router.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 import '../../../models/candidate_user.dart';
 import '../../../models/dog_response.dart';
@@ -131,11 +132,23 @@ class _CandidateCardState extends State<CandidateCard> {
                   onPageChanged: (i) => setState(() => _pageIndex = i),
                   children: _slides.map((slide) {
                     if (slide.imageUrl != null) {
-                      return Image.network(
-                        slide.imageUrl!,
+                      return CachedNetworkImage(
+                        imageUrl: slide.imageUrl!,
                         fit: BoxFit.cover,
                         width: double.infinity,
                         height: double.infinity,
+                        placeholder: (context, url) => const Center(
+                          child: CircularProgressIndicator(),
+                        ),
+                        errorWidget: (context, url, error) => Container(
+                          color: Colors.black12,
+                          alignment: Alignment.center,
+                          child: Icon(
+                            Icons.pets,
+                            size: 80,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                        ),
                       );
                     }
                     return Container(

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   stomp_dart_client: ^2.1.3
   flutter_local_notifications: ^19.2.1
   scrollable_positioned_list: ^0.3.8
+  cached_network_image: 3.4.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- update deps to include `cached_network_image`
- load candidate pictures via `CachedNetworkImage`

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f8324c6488323b1acb128cf61b7ff