### PR TITLE
Add settings service

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/match/service/MatchService.java
+++ b/backend/src/main/java/com/pawconnect/backend/match/service/MatchService.java
@@ -41,8 +41,10 @@ public class MatchService {
         User currentUser = userService.getCurrentUserEntity();
         Point loc = currentUser.getLocation();
 
+        double radiusM = radiusKm > 100 ? 50_000 * 1000.0 : radiusKm * 1000.0;
+
         List<RankedCandidateRow> rows = userRepository.findRankedCandidates(
-                currentUser.getId(), loc, radiusKm * 1000.0, limit);
+                currentUser.getId(), loc, radiusM, limit);
 
         // Load the User entities in batch so we can reuse the existing UserMapper
         List<Long> ids = rows.stream().map(RankedCandidateRow::getUser_id).toList();

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'src/app.dart';
 import 'src/services/http_client.dart';
+import 'src/services/settings_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await HttpClient.instance.init();
+  await SettingsService.instance.init();
   final hasCookie = await HttpClient.instance.hasAuthCookie();
   runApp(App(initialLocation: hasCookie ? '/home' : '/'));
 }

--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -11,6 +11,7 @@ import 'features/profile/presentation/profile_screen.dart';
 import 'features/profile/presentation/public_profile_screen.dart';
 import 'features/event/presentation/event_screen.dart';
 import 'features/dog/presentation/dog_profile_screen.dart';
+import 'features/settings/presentation/settings_screen.dart';
 import 'styles/app_theme.dart';
 
 class App extends StatelessWidget {
@@ -71,6 +72,10 @@ class App extends StatelessWidget {
           final id = int.parse(state.pathParameters['id']!);
           return ChatScreen(chatId: id);
         },
+      ),
+      GoRoute(
+        path: '/settings',
+        builder: (context, state) => const SettingsScreen(),
       ),
     ],
   );

--- a/mobile/lib/src/features/home/presentation/home_screen.dart
+++ b/mobile/lib/src/features/home/presentation/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_card_swiper/flutter_card_swiper.dart';
 
 import '../../../models/candidate_user.dart';
 import '../../../services/match_service.dart';
+import '../../../services/settings_service.dart';
 import '../../../shared/main_app_bar.dart';
 import 'candidate_card.dart';
 
@@ -27,7 +28,8 @@ class _HomeScreenState extends State<HomeScreen> {
   Future<void> _loadCandidates() async {
     setState(() => _loading = true);
     try {
-      final res = await MatchService.instance.getCandidates();
+      final res = await MatchService.instance
+          .getCandidates(radiusKm: SettingsService.instance.candidateDistanceKm);
       _candidates
         ..clear()
         ..addAll((res.data as List<dynamic>)
@@ -50,7 +52,26 @@ class _HomeScreenState extends State<HomeScreen> {
     if (_loading) {
       body = const Center(child: CircularProgressIndicator());
     } else if (_candidates.isEmpty) {
-      body = const Center(child: Text('No candidates found'));
+      body = Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('No candidates found'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                double newRadius =
+                    (SettingsService.instance.candidateDistanceKm + 5)
+                        .clamp(1, 101);
+                await SettingsService.instance
+                    .setCandidateDistanceKm(newRadius.toDouble());
+                _loadCandidates();
+              },
+              child: const Text('Increase search radius'),
+            ),
+          ],
+        ),
+      );
     } else {
       body = Center(
         child: CardSwiper(

--- a/mobile/lib/src/features/settings/presentation/settings_screen.dart
+++ b/mobile/lib/src/features/settings/presentation/settings_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../../../services/settings_service.dart';
+import '../../../shared/main_app_bar.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  late double _distance;
+
+  @override
+  void initState() {
+    super.initState();
+    _distance = SettingsService.instance.candidateDistanceKm;
+  }
+
+  Future<void> _save() async {
+    await SettingsService.instance.setCandidateDistanceKm(_distance);
+    if (mounted) Navigator.pop(context);
+  }
+
+  String _distanceLabel(double value) {
+    return value > 100 ? 'Any' : '${value.round()} km';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const MainAppBar(),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Candidate search radius',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            Slider(
+              min: 1,
+              max: 101,
+              divisions: 100,
+              value: _distance,
+              label: _distanceLabel(_distance),
+              onChanged: (v) => setState(() => _distance = v),
+            ),
+            Text('Selected: ${_distanceLabel(_distance)}'),
+            const SizedBox(height: 24),
+            Center(
+              child: ElevatedButton(
+                onPressed: _save,
+                child: const Text('Save'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/src/services/settings_service.dart
+++ b/mobile/lib/src/services/settings_service.dart
@@ -1,0 +1,22 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SettingsService {
+  SettingsService._();
+
+  static final SettingsService instance = SettingsService._();
+
+  late SharedPreferences _prefs;
+  double _candidateDistanceKm = 25;
+
+  Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+    _candidateDistanceKm = _prefs.getDouble('candidateDistanceKm') ?? 25;
+  }
+
+  double get candidateDistanceKm => _candidateDistanceKm;
+
+  Future<void> setCandidateDistanceKm(double value) async {
+    _candidateDistanceKm = value;
+    await _prefs.setDouble('candidateDistanceKm', value);
+  }
+}

--- a/mobile/lib/src/shared/main_app_bar.dart
+++ b/mobile/lib/src/shared/main_app_bar.dart
@@ -67,6 +67,12 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
       ),
       actions: [
         IconButton(
+          tooltip: 'Settings',
+          splashRadius: 24,
+          onPressed: () => context.push('/settings'),
+          icon: const Icon(Icons.settings),
+        ),
+        IconButton(
           tooltip: 'Logout',
           splashRadius: 24,
           onPressed: () => _confirmLogout(context),

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   flutter_local_notifications: ^19.2.1
   scrollable_positioned_list: ^0.3.8
   cached_network_image: 3.4.1
+  shared_preferences: 2.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `shared_preferences` dependency
- introduce `SettingsService` for storing distance preference
- add settings screen with slider
- open settings screen from app bar and register `/settings` route
- fetch match candidates using saved distance
- allow expanding search radius when no candidates are found
- support unlimited search radius in backend