### PR TITLE
Update swipe card info overlay layout

### DIFF
--- a/mobile/lib/src/features/home/presentation/candidate_card.dart
+++ b/mobile/lib/src/features/home/presentation/candidate_card.dart
@@ -185,9 +185,12 @@ class _CandidateCardState extends State<CandidateCard> {
                     }),
                   ),
                 ),
-                Align(
-                  alignment: Alignment.bottomCenter,
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 80,
                   child: Container(
+                    width: double.infinity,
                     padding: const EdgeInsets.all(16),
                     decoration: const BoxDecoration(
                       gradient: LinearGradient(


### PR DESCRIPTION
## Summary
- position info overlay above action buttons on swipe card
- expand gradient overlay to cover full width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68519c5664148323b0d0c4566eef09f2