### PR TITLE
Move action buttons below CandidateCard

### DIFF
--- a/mobile/lib/src/features/home/presentation/candidate_card.dart
+++ b/mobile/lib/src/features/home/presentation/candidate_card.dart
@@ -127,13 +127,6 @@ class _CandidateCardState extends State<CandidateCard> {
     }
   }
 
-  Widget _buildActionButton(IconData icon, VoidCallback onPressed) {
-    return FloatingActionButton.small(
-      heroTag: null,
-      onPressed: onPressed,
-      child: Icon(icon),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -238,37 +231,6 @@ class _CandidateCardState extends State<CandidateCard> {
                                     _slides[_pageIndex].subtitle,
                                     style: const TextStyle(color: Colors.white),
                                   ),
-                                const SizedBox(height: 16),
-                                Row(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    _buildActionButton(
-                                      Icons.replay,
-                                      () => widget.cardController.undo(),
-                                    ),
-                                    const SizedBox(width: 16),
-                                    _buildActionButton(
-                                      Icons.close,
-                                      () => widget.cardController.swipe(
-                                        CardSwiperDirection.left,
-                                      ),
-                                    ),
-                                    const SizedBox(width: 16),
-                                    _buildActionButton(
-                                      Icons.favorite,
-                                      () => widget.cardController.swipe(
-                                        CardSwiperDirection.right,
-                                      ),
-                                    ),
-                                    const SizedBox(width: 16),
-                                    _buildActionButton(
-                                      Icons.star,
-                                      () => widget.cardController.swipe(
-                                        CardSwiperDirection.top,
-                                      ),
-                                    ),
-                                  ],
-                                ),
                               ],
                             ),
                           ),

--- a/mobile/lib/src/features/home/presentation/home_screen.dart
+++ b/mobile/lib/src/features/home/presentation/home_screen.dart
@@ -73,40 +73,76 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
       );
     } else {
-      body = Center(
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final width = constraints.maxWidth;
-            final height = width * 10 / 7;
-            return SizedBox(
-              width: width,
-              height: height,
-              child: CardSwiper(
-                controller: _cardController,
-                cardsCount: _candidates.length,
-                numberOfCardsDisplayed: 1,
-                onSwipe: (int previousIndex, int? currentIndex,
-                    CardSwiperDirection direction) async {
-                  if (direction == CardSwiperDirection.left) {
-                    await _createSwipe(previousIndex, 'PASS');
-                  } else if (direction == CardSwiperDirection.right) {
-                    await _createSwipe(previousIndex, 'LIKE');
-                  }
-                  if (previousIndex == _candidates.length - 1) {
-                    _loadCandidates();
-                  }
-                  return true;
-                },
-                cardBuilder: (context, index, horizontalOffset, verticalOffset) {
-                  return CandidateCard(
-                    candidate: _candidates[index],
-                    cardController: _cardController,
-                  );
-                },
+      body = LayoutBuilder(
+        builder: (context, constraints) {
+          final width = constraints.maxWidth;
+          final height = width * 10 / 7;
+          return Column(
+            children: [
+              SizedBox(
+                width: width,
+                height: height,
+                child: CardSwiper(
+                  controller: _cardController,
+                  cardsCount: _candidates.length,
+                  numberOfCardsDisplayed: 1,
+                  onSwipe: (int previousIndex, int? currentIndex,
+                      CardSwiperDirection direction) async {
+                    if (direction == CardSwiperDirection.left) {
+                      await _createSwipe(previousIndex, 'PASS');
+                    } else if (direction == CardSwiperDirection.right) {
+                      await _createSwipe(previousIndex, 'LIKE');
+                    }
+                    if (previousIndex == _candidates.length - 1) {
+                      _loadCandidates();
+                    }
+                    return true;
+                  },
+                  cardBuilder:
+                      (context, index, horizontalOffset, verticalOffset) {
+                    return CandidateCard(
+                      candidate: _candidates[index],
+                      cardController: _cardController,
+                    );
+                  },
+                ),
               ),
-            );
-          },
-        ),
+              const Spacer(),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  FloatingActionButton.small(
+                    heroTag: null,
+                    onPressed: () => _cardController.undo(),
+                    child: const Icon(Icons.replay),
+                  ),
+                  const SizedBox(width: 16),
+                  FloatingActionButton(
+                    heroTag: null,
+                    onPressed: () =>
+                        _cardController.swipe(CardSwiperDirection.left),
+                    child: const Icon(Icons.close),
+                  ),
+                  const SizedBox(width: 16),
+                  FloatingActionButton(
+                    heroTag: null,
+                    onPressed: () =>
+                        _cardController.swipe(CardSwiperDirection.right),
+                    child: const Icon(Icons.favorite),
+                  ),
+                  const SizedBox(width: 16),
+                  FloatingActionButton.small(
+                    heroTag: null,
+                    onPressed: () =>
+                        _cardController.swipe(CardSwiperDirection.top),
+                    child: const Icon(Icons.star),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+            ],
+          );
+        },
       );
     }
 


### PR DESCRIPTION
## Summary
- position CandidateCard at the top of the HomeScreen
- show swipe action buttons below the card instead of inside it
- enlarge like/dislike buttons and keep buttons round

## Testing
- `dart` or `flutter` commands not available

------
https://chatgpt.com/codex/tasks/task_e_6851d47023588323ba7d68182d4b874e