### PR TITLE
Fix candidate card page reset

### DIFF
--- a/mobile/lib/src/features/home/presentation/candidate_card.dart
+++ b/mobile/lib/src/features/home/presentation/candidate_card.dart
@@ -22,7 +22,7 @@ class CandidateCard extends StatefulWidget {
 
 class _CandidateCardState extends State<CandidateCard> {
   late final PageController _pageController;
-  late final List<_Slide> _slides;
+  late List<_Slide> _slides;
   int _pageIndex = 0;
 
   int? _calculateAge(String? birthdate) {
@@ -46,6 +46,18 @@ class _CandidateCardState extends State<CandidateCard> {
     super.initState();
     _pageController = PageController();
     _slides = _buildSlides();
+  }
+
+  @override
+  void didUpdateWidget(covariant CandidateCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.candidate.id != widget.candidate.id) {
+      setState(() {
+        _pageIndex = 0;
+        _slides = _buildSlides();
+        _pageController.jumpToPage(0);
+      });
+    }
   }
 
   @override

--- a/mobile/lib/src/features/home/presentation/home_screen.dart
+++ b/mobile/lib/src/features/home/presentation/home_screen.dart
@@ -119,6 +119,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   cardBuilder:
                       (context, index, horizontalOffset, verticalOffset) {
                     return CandidateCard(
+                      key: ValueKey(_candidates[index].id),
                       candidate: _candidates[index],
                       cardController: _cardController,
                     );


### PR DESCRIPTION
## Summary
- update candidate card state when candidate changes
- give each CandidateCard a ValueKey for stable state

## Testing
- `flutter format lib/src/features/home/presentation/candidate_card.dart lib/src/features/home/presentation/home_screen.dart` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520c4cf0f8832386ab1b86db5eb261