### PR TITLE
Fix public profile lookup by id

### DIFF
--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -53,11 +53,11 @@ class App extends StatelessWidget {
         },
       ),
       GoRoute(
-        path: '/public/:username',
+        path: '/public/:id',
         name: 'public-profile',
         builder: (context, state) {
-          final username = state.pathParameters['username']!;
-          return PublicProfileScreen(username: username);
+          final id = int.parse(state.pathParameters['id']!);
+          return PublicProfileScreen(userId: id);
         },
       ),
       GoRoute(

--- a/mobile/lib/src/features/chat/presentation/chat_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_screen.dart
@@ -32,6 +32,7 @@ class _ChatScreenState extends State<ChatScreen> {
   bool _hasMore = true;
   final TextEditingController _controller = TextEditingController();
   int? _userId;
+  int? _otherUserId;
   ChatResponse? _chat;
 
   @override
@@ -62,6 +63,9 @@ class _ChatScreenState extends State<ChatScreen> {
     final userRes = await UserService.instance.getCurrentUser();
     _userId = CurrentUserResponse.fromJson(userRes.data).id;
     ChatSocketService.instance.setCurrentUserId(_userId!);
+    _otherUserId = _chat?.participantIds
+        .firstWhere((id) => id != _userId, orElse: () => -1);
+    if (_otherUserId == -1) _otherUserId = null;
     await _loadMessages();
     if (mounted) setState(() {});
     ChatSocketService.instance.connect();
@@ -165,7 +169,7 @@ class _ChatScreenState extends State<ChatScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: _chat != null
-          ? ChatAppBar(chat: _chat!)
+          ? ChatAppBar(chat: _chat!, otherUserId: _otherUserId)
           : const MainAppBar(),
       body: Stack(
         children: [

--- a/mobile/lib/src/features/chat/widgets/chat_app_bar.dart
+++ b/mobile/lib/src/features/chat/widgets/chat_app_bar.dart
@@ -5,7 +5,8 @@ import '../../../models/chat_response.dart';
 
 class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
   final ChatResponse chat;
-  const ChatAppBar({super.key, required this.chat});
+  final int? otherUserId;
+  const ChatAppBar({super.key, required this.chat, this.otherUserId});
 
   void _openPlaceholder(BuildContext context) {
     if (chat.type.toUpperCase() == 'GROUP') {
@@ -13,7 +14,9 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
         context.push('/events/${chat.eventId}');
       }
     } else {
-      context.push('/public/${chat.title}');
+      if (otherUserId != null) {
+        context.push('/public/$otherUserId');
+      }
     }
   }
 

--- a/mobile/lib/src/features/home/presentation/candidate_card.dart
+++ b/mobile/lib/src/features/home/presentation/candidate_card.dart
@@ -129,7 +129,7 @@ class _CandidateCardState extends State<CandidateCard> {
     if (slide.isOwner) {
       context.pushNamed(
         'public-profile',
-        pathParameters: {'username': widget.candidate.username},
+        pathParameters: {'id': widget.candidate.id.toString()},
       );
     } else if (slide.dogId != null) {
       context.pushNamed(
@@ -160,7 +160,7 @@ class _CandidateCardState extends State<CandidateCard> {
                     children: _slides.map((slide) {
                       if (slide.imageUrl != null) {
                         final tag = slide.isOwner
-                            ? 'user-${widget.candidate.username}'
+                            ? 'user-${widget.candidate.id}'
                             : 'dog-${slide.dogId}';
                         return Hero(
                           tag: tag,

--- a/mobile/lib/src/features/profile/presentation/public_profile_screen.dart
+++ b/mobile/lib/src/features/profile/presentation/public_profile_screen.dart
@@ -7,8 +7,8 @@ import '../../../models/dog_response.dart';
 import '../../../services/user_service.dart';
 
 class PublicProfileScreen extends StatefulWidget {
-  final String username;
-  const PublicProfileScreen({super.key, required this.username});
+  final int userId;
+  const PublicProfileScreen({super.key, required this.userId});
 
   @override
   State<PublicProfileScreen> createState() => _PublicProfileScreenState();
@@ -28,7 +28,7 @@ class _PublicProfileScreenState extends State<PublicProfileScreen> {
   Future<void> _loadUser() async {
     setState(() => _loading = true);
     try {
-      final res = await UserService.instance.getPublicUser(widget.username);
+      final res = await UserService.instance.getPublicUser(widget.userId);
       _user = PublicUserResponse.fromJson(res.data);
     } finally {
       if (mounted) setState(() => _loading = false);
@@ -244,7 +244,7 @@ class _PublicProfileScreenState extends State<PublicProfileScreen> {
                         expandedHeight: 400,
                         flexibleSpace: FlexibleSpaceBar(
                           background: Hero(
-                            tag: 'user-${_user!.username}',
+                            tag: 'user-${_user!.id}',
                             child: _user!.profilePhotoUrl != null
                                 ? CachedNetworkImage(
                                     imageUrl: _user!.profilePhotoUrl!,

--- a/mobile/lib/src/services/user_service.dart
+++ b/mobile/lib/src/services/user_service.dart
@@ -29,7 +29,7 @@ class UserService {
     return _dio.delete('/users/current/profile-photo');
   }
 
-  Future<Response<dynamic>> getPublicUser(String username) {
-    return _dio.get('/users/public/$username');
+  Future<Response<dynamic>> getPublicUser(int userId) {
+    return _dio.get('/users/$userId');
   }
 }


### PR DESCRIPTION
## Summary
- query user public profile by ID instead of username
- update route path and navigation to use `/public/:id`
- pass userId when opening a public profile from candidate and chat screens
- adjust hero tags to use the user ID

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858ae37b5e08323befdeee0932c8bd7