### PR TITLE
Add 404 image fallback on public profile

### DIFF
--- a/mobile/lib/src/features/profile/presentation/public_profile_screen.dart
+++ b/mobile/lib/src/features/profile/presentation/public_profile_screen.dart
@@ -175,6 +175,21 @@ class _PublicProfileScreenState extends State<PublicProfileScreen> {
                                 ? CachedNetworkImage(
                                     imageUrl: dog.photoUrls.first,
                                     fit: BoxFit.cover,
+                                    placeholder: (context, url) => const Center(
+                                        child: CircularProgressIndicator()),
+                                    errorWidget: (context, url, error) =>
+                                        Container(
+                                      color: Colors.black12,
+                                      alignment: Alignment.center,
+                                      child: Icon(
+                                        Icons.pets,
+                                        size: 48,
+                                        color:
+                                            Theme.of(context)
+                                                .colorScheme
+                                                .primary,
+                                      ),
+                                    ),
                                   )
                                 : Container(
                                     color: Colors.black12,
@@ -249,6 +264,18 @@ class _PublicProfileScreenState extends State<PublicProfileScreen> {
                                 ? CachedNetworkImage(
                                     imageUrl: _user!.profilePhotoUrl!,
                                     fit: BoxFit.cover,
+                                    placeholder: (context, url) =>
+                                        const Center(child: CircularProgressIndicator()),
+                                    errorWidget: (context, url, error) => Container(
+                                      color: Colors.black12,
+                                      alignment: Alignment.center,
+                                      child: Icon(
+                                        Icons.person,
+                                        size: 80,
+                                        color:
+                                            Theme.of(context).colorScheme.primary,
+                                      ),
+                                    ),
                                   )
                                 : Container(
                                     color: Colors.black12,


### PR DESCRIPTION
## Summary
- handle 404 errors when loading dog photo
- handle 404 errors when loading user photo

## Testing
- No tests run due to user request

------
https://chatgpt.com/codex/tasks/task_e_6858b2db83048323a9881118d464d2d7