### PR TITLE
Generate SAS URLs in candidate endpoint

### DIFF
--- a/backend/src/test/java/com/pawconnect/backend/match/service/MatchServiceTest.java
+++ b/backend/src/test/java/com/pawconnect/backend/match/service/MatchServiceTest.java
@@ -9,6 +9,7 @@ import com.pawconnect.backend.match.model.Swipe;
 import com.pawconnect.backend.match.repository.MatchRepository;
 import com.pawconnect.backend.match.repository.SwipeRepository;
 import com.pawconnect.backend.chat.service.ChatService;
+import com.pawconnect.backend.common.BlobStorageService;
 import com.pawconnect.backend.user.dto.PublicUserResponse;
 import com.pawconnect.backend.user.dto.UserMapper;
 import com.pawconnect.backend.user.model.User;
@@ -45,6 +46,8 @@ class MatchServiceTest {
     private UserMapper userMapper;
     @Mock
     private ChatService chatService;
+    @Mock
+    private BlobStorageService blobStorageService;
 
     @InjectMocks
     private MatchService matchService;


### PR DESCRIPTION
## Summary
- return signed blob URLs for candidate profile and dog photos
- add blob storage mock to `MatchServiceTest`

## Testing
- `./mvnw -q test` *(fails: unable to download Maven due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6858bef804c083238ecdc290fb68414b