### PR TITLE
Implement event map screen

### DIFF
--- a/mobile/lib/src/env.dart
+++ b/mobile/lib/src/env.dart
@@ -4,3 +4,8 @@ const String apiBaseUrl = String.fromEnvironment(
 );
 
 const String jwtCookieName = 'pawconnect-jwt';
+
+const String mapTileUrl = String.fromEnvironment(
+  'MAP_TILE_URL',
+  defaultValue: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+);

--- a/mobile/lib/src/features/map/presentation/map_screen.dart
+++ b/mobile/lib/src/features/map/presentation/map_screen.dart
@@ -1,5 +1,14 @@
 import 'package:flutter/material.dart';
-import '../../../shared/main_app_bar.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_location_marker/flutter_map_location_marker.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../../../env.dart';
+import '../../../models/event_response.dart';
+import '../../../services/event_service.dart';
 
 class MapScreen extends StatefulWidget {
   const MapScreen({super.key});
@@ -9,13 +18,164 @@ class MapScreen extends StatefulWidget {
 }
 
 class _MapScreenState extends State<MapScreen> {
+  final MapController _mapController = MapController();
+  LatLng? _userLocation;
+  final List<EventResponse> _events = [];
+  int? _selectedId;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  Future<void> _init() async {
+    setState(() => _loading = true);
+    try {
+      var permission = await Geolocator.checkPermission();
+      if (permission == LocationPermission.denied ||
+          permission == LocationPermission.deniedForever) {
+        permission = await Geolocator.requestPermission();
+      }
+      if (permission == LocationPermission.always ||
+          permission == LocationPermission.whileInUse) {
+        final pos = await Geolocator.getCurrentPosition();
+        _userLocation = LatLng(pos.latitude, pos.longitude);
+        final res = await EventService.instance.searchEvents(
+          latitude: pos.latitude,
+          longitude: pos.longitude,
+          radiusKm: 3.218688,
+          date: DateTime.now(),
+        );
+        _events
+          ..clear()
+          ..addAll((res.data as List<dynamic>)
+              .map((e) => EventResponse.fromJson(e as Map<String, dynamic>)));
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Widget _buildInfoCard() {
+    final event =
+        _events.firstWhere((e) => e.id == _selectedId, orElse: () => _events[0]);
+    return Card(
+      margin: const EdgeInsets.all(16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(event.title,
+                style:
+                    Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 4),
+            Text(DateFormat('yMMMd – HH:mm').format(event.eventDateTime)),
+            const SizedBox(height: 4),
+            Text(
+              '${event.latitude.toStringAsFixed(5)}, ${event.longitude.toStringAsFixed(5)}',
+            ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: () {
+                  context.pushNamed('event',
+                      pathParameters: {'id': event.id.toString()});
+                },
+                child: const Text('View Details'),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  List<Marker> _buildMarkers() {
+    return _events
+        .map(
+          (e) => Marker(
+            width: 40,
+            height: 40,
+            point: LatLng(e.latitude, e.longitude),
+            child: GestureDetector(
+              onTap: () {
+                setState(() {
+                  _selectedId = e.id;
+                });
+              },
+              child: Icon(
+                Icons.location_pin,
+                color: _selectedId == e.id ? Colors.green : Colors.red,
+                size: 40,
+              ),
+            ),
+          ),
+        )
+        .toList();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: MainAppBar(),
-      body: Center(
-        child: Text('Map page placeholder'),
-      ),
+    Widget body;
+    if (_loading) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (_userLocation == null) {
+      body = const Center(child: Text('Location unavailable'));
+    } else {
+      body = Stack(
+        children: [
+          FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+              center: _userLocation,
+              zoom: 15,
+            ),
+            children: [
+              TileLayer(
+                urlTemplate: mapTileUrl,
+                userAgentPackageName: 'com.example.pawconnect',
+                tileProvider: NetworkTileProvider(headers: const {
+                  'User-Agent': 'PawConnectApp/1.0 (Android)',
+                }),
+                attributionBuilder: (_) => Text.rich(
+                  TextSpan(children: [
+                    const TextSpan(text: '© OpenStreetMap contributors  •  '),
+                    WidgetSpan(
+                      child: GestureDetector(
+                        onTap: () => launchUrl(
+                            Uri.parse('https://www.openstreetmap.org/fixthemap')),
+                        child: const Text(
+                          'Fix the map',
+                          style: TextStyle(decoration: TextDecoration.underline),
+                        ),
+                      ),
+                    ),
+                  ]),
+                  textAlign: TextAlign.right,
+                ),
+              ),
+              const LocationMarkerLayer(),
+              MarkerLayer(markers: _buildMarkers()),
+            ],
+          ),
+          if (_selectedId != null)
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: _buildInfoCard(),
+            ),
+        ],
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Nearby Events')),
+      body: body,
     );
   }
 }

--- a/mobile/lib/src/models/event_response.dart
+++ b/mobile/lib/src/models/event_response.dart
@@ -1,0 +1,20 @@
+class EventResponse {
+  final int id;
+  final String title;
+  final String? description;
+  final DateTime eventDateTime;
+  final double latitude;
+  final double longitude;
+  final int hostId;
+  final List<int> participantIds;
+
+  EventResponse.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        title = json['title'],
+        description = json['description'],
+        eventDateTime = DateTime.parse(json['eventDateTime']),
+        latitude = (json['latitude'] as num).toDouble(),
+        longitude = (json['longitude'] as num).toDouble(),
+        hostId = json['hostId'],
+        participantIds = List<int>.from(json['participantIds'] ?? []);
+}

--- a/mobile/lib/src/services/event_service.dart
+++ b/mobile/lib/src/services/event_service.dart
@@ -1,0 +1,30 @@
+import 'package:dio/dio.dart';
+
+import 'http_client.dart';
+
+class EventService {
+  EventService._();
+
+  static final EventService instance = EventService._();
+  final Dio _dio = HttpClient.instance.dio;
+
+  Future<Response<dynamic>> searchEvents({
+    required double latitude,
+    required double longitude,
+    required double radiusKm,
+    required DateTime date,
+  }) {
+    final dateStr = date.toIso8601String().split('T').first;
+    return _dio.get(
+      '/events',
+      queryParameters: {
+        'near': '$latitude,$longitude,$radiusKm',
+        'date': dateStr,
+      },
+    );
+  }
+
+  Future<Response<dynamic>> getEvent(int id) {
+    return _dio.get('/events/$id');
+  }
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -52,6 +52,9 @@ dependencies:
   image_picker: ^1.0.7
   image_cropper: 9.1.0
   flutter_image_compress: ^2.1.0
+  flutter_map: 8.1.1
+  latlong2: ^0.9.1
+  flutter_map_location_marker: ^10.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- integrate OpenStreetMap tiles via new `mapTileUrl` constant
- add `EventService` and `EventResponse` model
- implement interactive map screen showing nearby events
- include new map packages

## Testing
- `dart format lib/src/env.dart lib/src/models/event_response.dart lib/src/services/event_service.dart lib/src/features/map/presentation/map_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859786fed688323855402032649eaa0