### PR TITLE
Add event creation screen and button on map

### DIFF
--- a/mobile/lib/src/app.dart
+++ b/mobile/lib/src/app.dart
@@ -10,6 +10,7 @@ import 'features/profile/profile_completion_screen.dart';
 import 'features/profile/presentation/profile_screen.dart';
 import 'features/profile/presentation/public_profile_screen.dart';
 import 'features/event/presentation/event_screen.dart';
+import 'features/event/presentation/event_create_screen.dart';
 import 'features/dog/presentation/dog_profile_screen.dart';
 import 'features/settings/presentation/settings_screen.dart';
 import 'styles/app_theme.dart';
@@ -67,6 +68,11 @@ class App extends StatelessWidget {
           final id = int.parse(state.pathParameters['id']!);
           return EventScreen(eventId: id);
         },
+      ),
+      GoRoute(
+        path: '/events/create',
+        name: 'event-create',
+        builder: (context, state) => const EventCreateScreen(),
       ),
       GoRoute(
         path: '/chats/:id',

--- a/mobile/lib/src/features/event/presentation/event_create_screen.dart
+++ b/mobile/lib/src/features/event/presentation/event_create_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class EventCreateScreen extends StatelessWidget {
+  const EventCreateScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Event')),
+      body: const Center(child: Text('Event creation form goes here')),
+    );
+  }
+}

--- a/mobile/lib/src/features/map/presentation/map_screen.dart
+++ b/mobile/lib/src/features/map/presentation/map_screen.dart
@@ -175,6 +175,10 @@ class _MapScreenState extends State<MapScreen> {
     return Scaffold(
       appBar: AppBar(title: const Text('Nearby Events')),
       body: body,
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.pushNamed('event-create'),
+        child: const Icon(Icons.add),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- create a simple `EventCreateScreen`
- add route for creating events
- show a floating action button on `MapScreen` to open the creation screen

## Testing
- `flutter format lib/src/app.dart lib/src/features/map/presentation/map_screen.dart lib/src/features/event/presentation/event_create_screen.dart` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c5f2c4cdc8323a804259bbc6b0a73