### PR TITLE
Add centered add event button on map

### DIFF
--- a/mobile/lib/src/features/map/presentation/map_screen.dart
+++ b/mobile/lib/src/features/map/presentation/map_screen.dart
@@ -175,9 +175,11 @@ class _MapScreenState extends State<MapScreen> {
     return Scaffold(
       appBar: AppBar(title: const Text('Nearby Events')),
       body: body,
-      floatingActionButton: FloatingActionButton(
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      floatingActionButton: FloatingActionButton.extended(
         onPressed: () => context.pushNamed('event-create'),
-        child: const Icon(Icons.add),
+        label: const Text('Add Event'),
+        icon: const Icon(Icons.add),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add an extended FloatingActionButton for creating events
- position the button at bottom center of the map

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c60b54e3483239ea732b4328ef8de