### PR TITLE
Update event search from today onwards

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/event/controller/EventController.java
+++ b/backend/src/main/java/com/pawconnect/backend/event/controller/EventController.java
@@ -6,14 +6,10 @@ import com.pawconnect.backend.event.model.EventParticipantStatus;
 import com.pawconnect.backend.event.service.EventService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
 @RestController
@@ -31,8 +27,7 @@ public class EventController {
 
     @GetMapping
     public ResponseEntity<List<EventResponse>> searchEvents(
-            @RequestParam("near") String near,
-            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+            @RequestParam("near") String near) {
         String[] parts = near.split(",");
         if (parts.length != 3) {
             return ResponseEntity.badRequest().build();
@@ -41,9 +36,7 @@ public class EventController {
         double longitude = Double.parseDouble(parts[1]);
         double radius = Double.parseDouble(parts[2]);
 
-        LocalDateTime from = date.atStartOfDay();
-        LocalDateTime to = date.atTime(LocalTime.MAX);
-        List<EventResponse> events = eventService.searchEvents(latitude, longitude, radius, from, to);
+        List<EventResponse> events = eventService.searchEvents(latitude, longitude, radius);
         return ResponseEntity.ok(events);
     }
 

--- a/backend/src/main/java/com/pawconnect/backend/event/repository/EventRepository.java
+++ b/backend/src/main/java/com/pawconnect/backend/event/repository/EventRepository.java
@@ -14,9 +14,8 @@ import java.util.List;
 public interface EventRepository extends JpaRepository<Event, Long> {
     @Query(value = "SELECT * FROM events e " +
             "WHERE ST_DWithin(e.location, :loc, :radiusM) " +
-            "AND e.event_date_time BETWEEN :from AND :to", nativeQuery = true)
+            "AND e.event_date_time >= :from", nativeQuery = true)
     List<Event> searchEvents(@Param("loc") Point loc,
                              @Param("radiusM") double radiusM,
-                             @Param("from") LocalDateTime from,
-                             @Param("to") LocalDateTime to);
+                             @Param("from") LocalDateTime from);
 }

--- a/backend/src/main/java/com/pawconnect/backend/event/service/EventService.java
+++ b/backend/src/main/java/com/pawconnect/backend/event/service/EventService.java
@@ -23,6 +23,7 @@ import org.locationtech.jts.geom.PrecisionModel;
 import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -49,10 +50,10 @@ public class EventService {
     }
 
     public List<EventResponse> searchEvents(double latitude, double longitude,
-                                            double radiusKm,
-                                            LocalDateTime from, LocalDateTime to) {
+                                            double radiusKm) {
         Point loc = geometryFactory.createPoint(new Coordinate(longitude, latitude));
-        List<Event> events = eventRepository.searchEvents(loc, radiusKm * 1000.0, from, to);
+        LocalDateTime from = LocalDate.now().atStartOfDay();
+        List<Event> events = eventRepository.searchEvents(loc, radiusKm * 1000.0, from);
         return events.stream().map(eventMapper::toDto).toList();
     }
 

--- a/mobile/lib/src/features/map/presentation/map_screen.dart
+++ b/mobile/lib/src/features/map/presentation/map_screen.dart
@@ -47,7 +47,6 @@ class _MapScreenState extends State<MapScreen> {
           latitude: pos.latitude,
           longitude: pos.longitude,
           radiusKm: 3.218688,
-          date: DateTime.now(),
         );
         _events
           ..clear()

--- a/mobile/lib/src/services/event_service.dart
+++ b/mobile/lib/src/services/event_service.dart
@@ -12,14 +12,11 @@ class EventService {
     required double latitude,
     required double longitude,
     required double radiusKm,
-    required DateTime date,
   }) {
-    final dateStr = date.toIso8601String().split('T').first;
     return _dio.get(
       '/events',
       queryParameters: {
         'near': '$latitude,$longitude,$radiusKm',
-        'date': dateStr,
       },
     );
   }


### PR DESCRIPTION
## Summary
- change backend search events query to return events from today onwards
- adjust service and controller accordingly
- update mobile client to match new search API

## Testing
- `./mvnw -q -DskipTests package` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c780e77188323b71b3f55c2fff03f