### PR TITLE
Fix event navigation to use pushReplacement

### DIFF
--- a/mobile/lib/src/features/event/presentation/event_create_screen.dart
+++ b/mobile/lib/src/features/event/presentation/event_create_screen.dart
@@ -107,7 +107,10 @@ class _EventCreateScreenState extends State<EventCreateScreen> {
       });
       if (!mounted) return;
       final event = EventResponse.fromJson(res.data);
-      context.goNamed('event', pathParameters: {'id': event.id.toString()});
+      context.pushReplacementNamed(
+        'event',
+        pathParameters: {'id': event.id.toString()},
+      );
     } on DioException catch (e) {
       final message = e.response?.data['message'] ?? e.message;
       if (mounted) {


### PR DESCRIPTION
## Summary
- use `pushReplacementNamed` for the event screen after creating an event

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c90f6576c8323a5dcf2d2d8a05f41