### PR TITLE
Fix list refresh after new dog/event creation

### DIFF
--- a/mobile/lib/src/features/map/presentation/map_screen.dart
+++ b/mobile/lib/src/features/map/presentation/map_screen.dart
@@ -182,7 +182,12 @@ class _MapScreenState extends State<MapScreen> {
       body: body,
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
       floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => context.pushNamed('event-create'),
+        onPressed: () async {
+          await context.pushNamed('event-create');
+          if (mounted) {
+            _init();
+          }
+        },
         label: const Text('Add Event'),
         icon: const Icon(Icons.add),
       ),

--- a/mobile/lib/src/features/profile/presentation/profile_screen.dart
+++ b/mobile/lib/src/features/profile/presentation/profile_screen.dart
@@ -285,7 +285,12 @@ class _ProfileScreenState extends State<ProfileScreen> {
               itemBuilder: (context, index) {
                 if (index == _user!.dogs.length) {
                   return GestureDetector(
-                    onTap: () => context.pushNamed('dog-create'),
+                    onTap: () async {
+                      await context.pushNamed('dog-create');
+                      if (mounted) {
+                        _loadUser();
+                      }
+                    },
                     child: SizedBox(
                       width: 140,
                       child: Card(


### PR DESCRIPTION
## Summary
- refresh the nearby events map after returning from event creation
- refresh the profile's dogs list after returning from dog creation

## Testing
- `dart format mobile/lib/src/features/map/presentation/map_screen.dart mobile/lib/src/features/profile/presentation/profile_screen.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c9b20d54083238a538eb5ca6103b5