### PR TITLE
Add Authorization header parsing for WebSockets

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/auth/jwt/AuthTokenFilter.java
+++ b/backend/src/main/java/com/pawconnect/backend/auth/jwt/AuthTokenFilter.java
@@ -88,6 +88,10 @@ public class AuthTokenFilter extends OncePerRequestFilter {
 
 
     private String parseJwt(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
         return jwtUtils.getJwtFromCookies(request);
     }
 }


### PR DESCRIPTION
## Summary
- support `Authorization: Bearer <token>` header in `AuthTokenFilter` so WebSocket handshakes can authenticate with JWT

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_685cadc7125c8323892618ae2487b12a