### PR TITLE
Fix websocket auth by widening JWT cookie path

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/common/util/JwtUtils.java
+++ b/backend/src/main/java/com/pawconnect/backend/common/util/JwtUtils.java
@@ -41,11 +41,21 @@ public class JwtUtils {
 
     public ResponseCookie generateJwtCookie(UserDetailsImpl userPrincipal) {
         String jwt = generateTokenFromUsername(userPrincipal.getUsername());
-        return ResponseCookie.from(jwtCookie, jwt).path("/api").maxAge(24 * 60 * 60).httpOnly(true).build();
+        // Make the cookie available for the entire application so that
+        // websocket handshake requests (e.g. to /ws-chat) also include it.
+        return ResponseCookie.from(jwtCookie, jwt)
+                .path("/")
+                .maxAge(24 * 60 * 60)
+                .httpOnly(true)
+                .build();
     }
 
     public ResponseCookie getCleanJwtCookie() {
-        return ResponseCookie.from(jwtCookie, null).path("/api").build();
+        // Use the same root path as the authentication cookie to ensure
+        // the client removes it correctly.
+        return ResponseCookie.from(jwtCookie, null)
+                .path("/")
+                .build();
     }
 
     public String getUserNameFromJwtToken(String token) {


### PR DESCRIPTION
## Summary
- ensure login cookie is available for websocket connections

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685caf3d7174832384f967a36e2e532e