### PR TITLE
Fix WebSocket auth context

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@
 
 The backend exposes a STOMP endpoint at `/ws-chat`. The handshake requires a valid JWT,
 so include the token in the `Authorization` header (or cookie) when connecting
-with a WebSocket or SockJS client.
+with a WebSocket or SockJS client. Each message is sent on behalf of the authenticated
+`Principal` from the WebSocket session. The controller places that authentication into
+the `SecurityContext` before saving the message so that regular service-layer security
+checks continue to work.
 
 ### Endpoints
 

--- a/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatController.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatController.java
@@ -6,7 +6,11 @@ import com.pawconnect.backend.chat.service.MessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
 
 @Controller
 @RequiredArgsConstructor
@@ -16,7 +20,10 @@ public class ChatController {
     private final SimpMessagingTemplate messagingTemplate;
 
     @MessageMapping("/chat.send")
-    public void sendMessage(ChatMessageRequest request) {
+    public void sendMessage(Principal principal, ChatMessageRequest request) {
+        if (principal instanceof Authentication authentication) {
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
         ChatMessageResponse msg = messageService.saveMessage(request);
         messagingTemplate.convertAndSend("/topic/chats/" + msg.getChatId(), msg);
     }

--- a/backend/src/test/java/com/pawconnect/backend/chat/controller/ChatControllerTest.java
+++ b/backend/src/test/java/com/pawconnect/backend/chat/controller/ChatControllerTest.java
@@ -10,7 +10,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+
 import static org.mockito.Mockito.*;
+
+import org.springframework.security.core.Authentication;
 
 @ExtendWith(MockitoExtension.class)
 class ChatControllerTest {
@@ -28,7 +31,8 @@ class ChatControllerTest {
         resp.setChatId(5L);
         when(messageService.saveMessage(req)).thenReturn(resp);
 
-        chatController.sendMessage(req);
+        Authentication authentication = mock(Authentication.class);
+        chatController.sendMessage(authentication, req);
 
         verify(messagingTemplate).convertAndSend("/topic/chats/5", resp);
     }


### PR DESCRIPTION
## Summary
- wire `Principal` into `ChatController.sendMessage`
- cast `Principal` to `Authentication` and set security context
- adjust unit test
- document WebSocket auth flow

## Testing
- No tests run due to instructions

------
https://chatgpt.com/codex/tasks/task_e_685cb2eaed40832391b62db4aa25ce2c