### PR TITLE
Fix duplicate message bubble for sender

### DIFF
--- a/mobile/lib/src/features/chat/presentation/chat_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_screen.dart
@@ -78,7 +78,17 @@ class _ChatScreenState extends State<ChatScreen> {
         .messagesForChat(widget.chatId)
         .listen((msg) {
       if (!mounted) return;
-      setState(() => _messages.add(msg));
+      final idx = _messages.indexWhere(
+        (m) =>
+            m.senderId == msg.senderId &&
+            m.timestamp == msg.timestamp &&
+            m.content == msg.content,
+      );
+      if (idx != -1) {
+        setState(() => _messages[idx] = msg);
+      } else {
+        setState(() => _messages.add(msg));
+      }
       _scrollController.scrollTo(
         index: _items.length - 1,
         duration: const Duration(milliseconds: 200),


### PR DESCRIPTION
## Summary
- update ChatScreen so resending the same message from ChatSocketService
  replaces the pending entry instead of adding a new one

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cbd8574e48323a7df53637e59c8bd