### PR TITLE
Add unread messages tracking

### DIFF
--- a/mobile/lib/src/models/chat_response.dart
+++ b/mobile/lib/src/models/chat_response.dart
@@ -11,6 +11,16 @@ class ChatResponse {
   final ChatMessageResponse? lastMessage;
   final int unreadCount;
 
+  const ChatResponse({
+    required this.id,
+    required this.type,
+    required this.title,
+    this.eventId,
+    this.participantIds = const [],
+    this.lastMessage,
+    this.unreadCount = 0,
+  });
+
   ChatResponse.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         type = json['type'],
@@ -22,4 +32,18 @@ class ChatResponse {
                 json['lastMessage'] as Map<String, dynamic>)
             : null,
         unreadCount = json['unreadCount'] ?? 0;
+
+  ChatResponse copyWith({int? unreadCount}) {
+    return ChatResponse(
+      id: id,
+      type: type,
+      title: title,
+      eventId: eventId,
+      participantIds: List<int>.from(participantIds),
+      lastMessage: lastMessage != null
+          ? ChatMessageResponse.fromJson(lastMessage!.toJson())
+          : null,
+      unreadCount: unreadCount ?? this.unreadCount,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- track unread messages per chat in `ChatSocketService`
- expose unread count updates through a stream
- update unread counts when receiving new messages
- listen for unread count updates in `ChatListScreen`
- add a constructor and `copyWith` for `ChatResponse`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685cfe1d1fa08323ba18a43dd6580d8b