### PR TITLE
Update sender read status when sending messages

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/chat/repository/ChatParticipantRepository.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/repository/ChatParticipantRepository.java
@@ -2,8 +2,10 @@ package com.pawconnect.backend.chat.repository;
 
 import com.pawconnect.backend.chat.model.ChatParticipant;
 import com.pawconnect.backend.chat.model.ChatParticipantId;
+import com.pawconnect.backend.chat.model.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -12,4 +14,15 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
     boolean existsByChatIdAndUserId(Long chatId, Long userId);
     void deleteByChatIdAndUserId(Long chatId, Long userId);
     Optional<ChatParticipant> findByChatIdAndUserId(Long chatId, Long userId);
+
+    /**
+     * Update the last read message for a participant.
+     */
+    @Transactional
+    default void updateLastReadMessage(Long chatId, Long userId, Message message) {
+        findByChatIdAndUserId(chatId, userId).ifPresent(p -> {
+            p.setLastReadMessage(message);
+            save(p);
+        });
+    }
 }

--- a/backend/src/main/java/com/pawconnect/backend/chat/service/MessageService.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/service/MessageService.java
@@ -43,6 +43,9 @@ public class MessageService {
                 .build();
         Message saved = messageRepository.save(message);
 
+        // Mark the message as read for the sender
+        chatParticipantRepository.updateLastReadMessage(chat.getId(), sender.getId(), saved);
+
         ChatMessageResponse res = new ChatMessageResponse();
         res.setId(saved.getId());
         res.setChatId(chat.getId());


### PR DESCRIPTION
## Summary
- track last read message for sender when saving a message
- add helper to `ChatParticipantRepository` for updating the read pointer

## Testing
- `mvn -q -DskipTests package` *(fails: internet access needed to download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_685d00543de8832395dc474de6b20b41