### PR TITLE
Add message read API and client sync

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatRestController.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatRestController.java
@@ -38,4 +38,10 @@ public class ChatRestController {
             @RequestParam(defaultValue = "20") int limit) {
         return ResponseEntity.ok(messageService.getMessages(chatId, page, limit));
     }
+
+    @PatchMapping("/{chatId}/read/{messageId}")
+    public ResponseEntity<Void> markAsRead(@PathVariable Long chatId, @PathVariable Long messageId) {
+        messageService.markAsRead(chatId, messageId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/pawconnect/backend/chat/service/MessageService.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/service/MessageService.java
@@ -88,4 +88,20 @@ public class MessageService {
                 })
                 .toList();
     }
+
+    public void markAsRead(Long chatId, Long messageId) {
+        User user = userService.getCurrentUserEntity();
+        if (!chatRepository.existsByIdAndParticipantsUserId(chatId, user.getId())) {
+            throw new UnauthorizedAccessException("You are not a participant of this chat");
+        }
+
+        Message message = messageRepository.findById(messageId)
+                .orElseThrow(() -> new NotFoundException("Message not found"));
+
+        if (!message.getChat().getId().equals(chatId)) {
+            throw new NotFoundException("Message not found in this chat");
+        }
+
+        chatParticipantRepository.updateLastReadMessage(chatId, user.getId(), message);
+    }
 }

--- a/mobile/lib/src/services/chat_service.dart
+++ b/mobile/lib/src/services/chat_service.dart
@@ -17,4 +17,8 @@ class ChatService {
     return _dio.get('/chats/$chatId/messages',
         queryParameters: {'page': page, 'limit': limit});
   }
+
+  Future<Response<dynamic>> markAsRead(int chatId, int messageId) {
+    return _dio.patch('/chats/$chatId/read/$messageId');
+  }
 }

--- a/mobile/lib/src/services/chat_socket_service.dart
+++ b/mobile/lib/src/services/chat_socket_service.dart
@@ -6,6 +6,7 @@ import 'http_client.dart';
 import '../models/chat_message_response.dart';
 import '../models/chat_message.dart';
 import '../models/chat_response.dart';
+import 'chat_service.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -144,6 +145,11 @@ onStompError: (frame) {
             _unreadCountStream.add(Map.from(_unreadCounts));
             _showNotification(res);
           }
+        }
+        if (_activeChatId == msg.chatId) {
+          _unreadCounts[msg.chatId] = 0;
+          _unreadCountStream.add(Map.from(_unreadCounts));
+          ChatService.instance.markAsRead(msg.chatId, res.id);
         }
       },
     );


### PR DESCRIPTION
## Summary
- add `PATCH /api/chats/{chatId}/read/{messageId}` endpoint
- implement message read update in backend service
- expose `markAsRead` function in mobile chat service
- invoke the new API from `ChatSocketService`

## Testing
- `./backend/mvnw -q test` *(fails: cannot download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d014619f0832396adf5b0984d6905