### PR TITLE
Update chat unread counters

### DIFF
--- a/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatRestController.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/controller/ChatRestController.java
@@ -40,8 +40,8 @@ public class ChatRestController {
     }
 
     @PatchMapping("/{chatId}/read/{messageId}")
-    public ResponseEntity<Void> markAsRead(@PathVariable Long chatId, @PathVariable Long messageId) {
-        messageService.markAsRead(chatId, messageId);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<ChatResponse> markAsRead(@PathVariable Long chatId, @PathVariable Long messageId) {
+        ChatResponse res = messageService.markAsRead(chatId, messageId);
+        return ResponseEntity.ok(res);
     }
 }

--- a/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/service/ChatService.java
@@ -99,6 +99,16 @@ public class ChatService {
         return getChatEntity(chatId);
     }
 
+    /**
+     * Retrieve chat details for the currently authenticated user including
+     * latest message metadata and unread count.
+     */
+    public ChatResponse getChatForCurrentUserDto(Long chatId) {
+        Long userId = userService.getCurrentUserEntity().getId();
+        Chat chat = getChatForUser(chatId, userId);
+        return buildChatResponse(chat, userId);
+    }
+
     public List<ChatResponse> getCurrentUserChats() {
         Long userId = userService.getCurrentUserEntity().getId();
         return getChatsByUserId(userId);

--- a/backend/src/main/java/com/pawconnect/backend/chat/service/MessageService.java
+++ b/backend/src/main/java/com/pawconnect/backend/chat/service/MessageService.java
@@ -7,6 +7,8 @@ import com.pawconnect.backend.chat.model.Message;
 import com.pawconnect.backend.chat.repository.ChatRepository;
 import com.pawconnect.backend.chat.repository.ChatParticipantRepository;
 import com.pawconnect.backend.chat.repository.MessageRepository;
+import com.pawconnect.backend.chat.dto.ChatResponse;
+import com.pawconnect.backend.chat.service.ChatService;
 import com.pawconnect.backend.common.exception.NotFoundException;
 import com.pawconnect.backend.common.exception.UnauthorizedAccessException;
 import com.pawconnect.backend.user.model.User;
@@ -26,6 +28,7 @@ public class MessageService {
     private final ChatRepository chatRepository;
     private final UserService userService;
     private final ChatParticipantRepository chatParticipantRepository;
+    private final ChatService chatService;
 
     public ChatMessageResponse saveMessage(ChatMessageRequest request) {
         Chat chat = chatRepository.findById(request.getChatId())
@@ -89,7 +92,7 @@ public class MessageService {
                 .toList();
     }
 
-    public void markAsRead(Long chatId, Long messageId) {
+    public ChatResponse markAsRead(Long chatId, Long messageId) {
         User user = userService.getCurrentUserEntity();
         if (!chatRepository.existsByIdAndParticipantsUserId(chatId, user.getId())) {
             throw new UnauthorizedAccessException("You are not a participant of this chat");
@@ -103,5 +106,6 @@ public class MessageService {
         }
 
         chatParticipantRepository.updateLastReadMessage(chatId, user.getId(), message);
+        return chatService.getChatForCurrentUserDto(chatId);
     }
 }

--- a/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
+++ b/mobile/lib/src/features/chat/presentation/chat_list_screen.dart
@@ -58,6 +58,7 @@ class _ChatListScreenState extends State<ChatListScreen> {
         ..addAll((res.data as List<dynamic>)
             .map((e) => ChatResponse.fromJson(e as Map<String, dynamic>)));
       ChatSocketService.instance.updateChatTitles(_chats);
+      ChatSocketService.instance.syncUnreadCounts(_chats);
       for (final chat in _chats) {
         ChatSocketService.instance.subscribe(chat.id);
       }


### PR DESCRIPTION
## Summary
- sync server unread counts with local counters in chat list
- return chat details when marking messages as read
- update WebSocket handling to use new unread values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d02bfc42083239b0a6309f5502e51