### PR TITLE
Show sender names in group chats

### DIFF
--- a/mobile/lib/src/features/chat/widgets/message_bubbles.dart
+++ b/mobile/lib/src/features/chat/widgets/message_bubbles.dart
@@ -7,7 +7,13 @@ import '../../../services/chat_socket_service.dart';
 class MessageBubble extends StatelessWidget {
   final ChatMessage message;
   final bool isMe;
-  const MessageBubble({super.key, required this.message, required this.isMe});
+  final String? username;
+  const MessageBubble({
+    super.key,
+    required this.message,
+    required this.isMe,
+    this.username,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -35,8 +41,19 @@ class MessageBubble extends StatelessWidget {
             ),
           ),
           child: Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
+            crossAxisAlignment:
+                isMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
             children: [
+              if (!isMe && username != null) ...[
+                Text(
+                  username!,
+                  style: Theme.of(context)
+                      .textTheme
+                      .labelSmall
+                      ?.copyWith(color: textColor),
+                ),
+                const SizedBox(height: 2),
+              ],
               Text(message.content, style: TextStyle(color: textColor)),
               const SizedBox(height: 4),
               Row(
@@ -97,7 +114,10 @@ class SentMessageBubble extends MessageBubble {
 }
 
 class ReceivedMessageBubble extends MessageBubble {
-  const ReceivedMessageBubble({super.key, required super.message})
-      : super(isMe: false);
+  const ReceivedMessageBubble({
+    super.key,
+    required super.message,
+    String? username,
+  }) : super(isMe: false, username: username);
 }
 


### PR DESCRIPTION
## Summary
- show username above message bubble when in group chats
- preload usernames for group chat participants

## Testing
- `dart` and `flutter` commands are unavailable in the environment so formatting and tests were skipped

------
https://chatgpt.com/codex/tasks/task_e_685d0ac2e17c832393b3055b79487af0